### PR TITLE
Replaced contracts in DB with cloned models

### DIFF
--- a/Api/Extensions/BookingExtensions.cs
+++ b/Api/Extensions/BookingExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Linq;
-using HappyTravel.EdoContracts.Accommodations;
+using HappyTravel.Edo.Data.Booking;
 using HappyTravel.Money.Helpers;
 using Booking = HappyTravel.Edo.Data.Booking.Booking;
 
@@ -10,7 +10,9 @@ namespace HappyTravel.Edo.Api.Extensions
     {
         public static decimal GetRefundableAmount(this Booking booking, DateTime forDate)
         {
-            var refundableAmount = booking.Rooms.Sum(room => room.Price.Amount * (decimal)room.DeadlineDetails.GetRefundableFraction(forDate));
+            var refundableAmount = booking.Rooms.Sum(room => room.Price.Amount * 
+                (decimal)room.DeadlineDetails.GetRefundableFraction(forDate));
+            
             return MoneyRounder.Ceil(refundableAmount, booking.Currency);
         }
 

--- a/Api/Extensions/BookingExtensions.cs
+++ b/Api/Extensions/BookingExtensions.cs
@@ -30,7 +30,7 @@ namespace HappyTravel.Edo.Api.Extensions
 
             var appliedPolicy = deadline.Policies.OrderBy(p => p.FromDate).LastOrDefault(p => p.FromDate <= forDate);
 
-            return appliedPolicy.Equals(default)
+            return appliedPolicy == default
                 ? Nothing
                 : appliedPolicy.Percentage / 100;
         }

--- a/Api/Models/Bookings/BookingVoucherData.cs
+++ b/Api/Models/Bookings/BookingVoucherData.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using HappyTravel.Edo.Data.Booking;
 using HappyTravel.EdoContracts.Accommodations.Enums;
 using HappyTravel.EdoContracts.Accommodations.Internals;
 using HappyTravel.EdoContracts.General;
@@ -55,7 +56,7 @@ namespace HappyTravel.Edo.Api.Models.Bookings
         public readonly struct RoomInfo
         {
             public RoomInfo(RoomTypes type, BoardBasisTypes boardBasis, string mealPlan,
-                DateTime? deadlineDate, string contractDescription, List<Pax> passengers,
+                DateTime? deadlineDate, string contractDescription, List<Passenger> passengers,
                 List<KeyValuePair<string, string>> remarks, string supplierRoomReferenceCode)
             {
                 Type = type;
@@ -73,7 +74,7 @@ namespace HappyTravel.Edo.Api.Models.Bookings
             public string MealPlan { get; }
             public DateTime? DeadlineDate { get; }
             public string ContractDescription { get; }
-            public List<Pax> Passengers { get; }
+            public List<Passenger> Passengers { get; }
             public List<KeyValuePair<string, string>> Remarks { get; }
             public string SupplierRoomReferenceCode { get; }
         }

--- a/Api/Services/Accommodations/Bookings/BookingAuditLogService.cs
+++ b/Api/Services/Accommodations/Bookings/BookingAuditLogService.cs
@@ -2,6 +2,7 @@
 using HappyTravel.Edo.Data;
 using HappyTravel.Edo.Data.Booking;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
 using Booking = HappyTravel.EdoContracts.Accommodations.Booking;
 
 namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
@@ -36,7 +37,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
             {
                 BookingId = bookingId,
                 AgentId = agentId,
-                BookingDetails = newBookingDetails,
+                BookingDetails = JsonConvert.SerializeObject(newBookingDetails),
             });
             
             return _edoContext.SaveChangesAsync();

--- a/Api/Services/Accommodations/Bookings/BookingFactory.cs
+++ b/Api/Services/Accommodations/Bookings/BookingFactory.cs
@@ -95,12 +95,23 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
                             r.Deadline.Date,
                             r.ContractDescription,
                             r.Remarks,
-                            r.Deadline,
+                            GetDeadline(r.Deadline),
                             GetCorrespondingPassengers(number),
                             string.Empty))
                     .ToList();
                 
-                List<Pax> GetCorrespondingPassengers(int number) => bookingRequestRoomDetails[number].Passengers;
+                List<Passenger> GetCorrespondingPassengers(int number) => bookingRequestRoomDetails[number].Passengers
+                    .Select(p=> new Passenger(p.Title, p.LastName, p.FirstName, p.IsLeader, p.Age))
+                    .ToList();
+
+
+                Deadline GetDeadline(EdoContracts.Accommodations.Deadline deadline)
+                {
+                    var policies = deadline.Policies
+                        .Select(p => new Data.Booking.CancellationPolicy(p.FromDate, p.Percentage)).ToList();
+                    
+                    return new Deadline(deadline.Date, policies, deadline.Remarks);
+                }
             }
         }
     }

--- a/Api/Services/Mailing/BookingMailingService.cs
+++ b/Api/Services/Mailing/BookingMailingService.cs
@@ -469,7 +469,7 @@ namespace HappyTravel.Edo.Api.Services.Mailing
                 .SelectMany(r =>
                 {
                     if (r.Passengers == null)
-                        return new List<Pax>(0);
+                        return new List<Passenger>(0);
                     
                     return r.Passengers.Where(p => p.IsLeader);
                 })

--- a/HappyTravel.Edo.Data/Booking/BookedRoom.cs
+++ b/HappyTravel.Edo.Data/Booking/BookedRoom.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using HappyTravel.EdoContracts.Accommodations;
 using HappyTravel.EdoContracts.Accommodations.Enums;
-using HappyTravel.EdoContracts.General;
 using HappyTravel.Money.Models;
 
 namespace HappyTravel.Edo.Data.Booking
@@ -15,7 +13,7 @@ namespace HappyTravel.Edo.Data.Booking
         }
         
         public BookedRoom(RoomTypes type, bool isExtraBedNeeded, MoneyAmount price, BoardBasisTypes boardBasis, string mealPlan, 
-            DateTime? deadlineDate, string contractDescription, List<KeyValuePair<string, string>> remarks, Deadline deadlineDetails, List<Pax> passengers,
+            DateTime? deadlineDate, string contractDescription, List<KeyValuePair<string, string>> remarks, Deadline deadlineDetails, List<Passenger> passengers,
             string supplierRoomReferenceCode)
         {
             Type = type;
@@ -29,7 +27,7 @@ namespace HappyTravel.Edo.Data.Booking
             ContractDescription = contractDescription;
             Remarks = remarks ?? new List<KeyValuePair<string, string>>(0);
             DeadlineDetails = deadlineDetails;
-            Passengers = passengers ?? new List<Pax>(0);
+            Passengers = passengers ?? new List<Passenger>(0);
         }
 
 
@@ -48,7 +46,7 @@ namespace HappyTravel.Edo.Data.Booking
         public RoomTypes Type { get; set;}
         public bool IsExtraBedNeeded { get; set;}
         public MoneyAmount Price { get; set;}
-        public List<Pax> Passengers { get; set;}
+        public List<Passenger> Passengers { get; set;}
         public string SupplierRoomReferenceCode { get; set;}
     }
 }

--- a/HappyTravel.Edo.Data/Booking/BookingAuditLogEntry.cs
+++ b/HappyTravel.Edo.Data/Booking/BookingAuditLogEntry.cs
@@ -8,6 +8,6 @@ namespace HappyTravel.Edo.Data.Booking
         public int BookingId { get; set; }
         public int AgentId { get; set; }
         public DateTime CreatedAt { get; set; }
-        public EdoContracts.Accommodations.Booking  BookingDetails {get; set; }
+        public string BookingDetails {get; set; }
     }
 }

--- a/HappyTravel.Edo.Data/Booking/CancellationPolicy.cs
+++ b/HappyTravel.Edo.Data/Booking/CancellationPolicy.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace HappyTravel.Edo.Data.Booking
+{
+    public class CancellationPolicy
+    {
+        // EF constructor
+        private CancellationPolicy() { }
+
+        public CancellationPolicy(DateTime fromDate, double percentage)
+        {
+            FromDate = fromDate;
+            Percentage = percentage;
+        }
+        
+        public DateTime FromDate { get; set; }
+        public double Percentage { get; set; }
+    }
+}

--- a/HappyTravel.Edo.Data/Booking/Deadline.cs
+++ b/HappyTravel.Edo.Data/Booking/Deadline.cs
@@ -11,7 +11,7 @@ namespace HappyTravel.Edo.Data.Booking
         public Deadline(DateTime? date, List<CancellationPolicy> policies, List<string> remarks = null)
         {
             Date = date;
-            Policies = policies;
+            Policies = policies ?? new List<CancellationPolicy>();
             Remarks = remarks ?? new List<string>(0);
         }
         

--- a/HappyTravel.Edo.Data/Booking/Deadline.cs
+++ b/HappyTravel.Edo.Data/Booking/Deadline.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace HappyTravel.Edo.Data.Booking
+{
+    public class Deadline
+    {
+        // EF constructor
+        private Deadline() {}
+
+        public Deadline(DateTime? date, List<CancellationPolicy> policies, List<string> remarks = null)
+        {
+            Date = date;
+            Policies = policies;
+            Remarks = remarks ?? new List<string>(0);
+        }
+        
+        public DateTime? Date { get; set; }
+        public List<CancellationPolicy> Policies { get; set; }
+        public List<string> Remarks { get; set; }
+    }
+}

--- a/HappyTravel.Edo.Data/Booking/Passenger.cs
+++ b/HappyTravel.Edo.Data/Booking/Passenger.cs
@@ -1,0 +1,26 @@
+using HappyTravel.EdoContracts.General.Enums;
+
+namespace HappyTravel.Edo.Data.Booking
+{
+    public class Passenger
+    {
+        // EF constructor
+        private Passenger() { }
+
+
+        public Passenger(PassengerTitles title, string lastName, string firstName, bool isLeader, int? age)
+        {
+            Title = title;
+            LastName = lastName;
+            FirstName = firstName;
+            IsLeader = isLeader;
+            Age = age;
+        }
+
+        public int? Age { get; set; }
+        public string FirstName { get; set; }
+        public bool IsLeader { get; set; }
+        public string LastName { get; set; }
+        public PassengerTitles Title { get; set; }
+    }
+}

--- a/HappyTravel.Edo.Data/EdoContext.cs
+++ b/HappyTravel.Edo.Data/EdoContext.cs
@@ -704,9 +704,6 @@ namespace HappyTravel.Edo.Data
 
                 br.Property(b => b.BookingDetails)
                     .HasColumnType("jsonb")
-                    .HasConversion(
-                        value => JsonConvert.SerializeObject(value),
-                        value => JsonConvert.DeserializeObject<EdoContracts.Accommodations.Booking>(value))
                     .IsRequired();
             });
         }

--- a/HappyTravel.Edo.UnitTests/Tests/Extensions/BookingExtensionsTests/MoneyRefundCalculation.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Extensions/BookingExtensionsTests/MoneyRefundCalculation.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using HappyTravel.Edo.Api.Extensions;
 using HappyTravel.Edo.Data.Booking;
-using HappyTravel.EdoContracts.Accommodations;
-using HappyTravel.EdoContracts.Accommodations.Internals;
 using HappyTravel.EdoContracts.General;
 using HappyTravel.Money.Enums;
 using HappyTravel.Money.Models;
@@ -129,7 +127,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Extensions.BookingExtensionsTests
 
 
         private BookedRoom MakeBookedRoom(Deadline deadline, MoneyAmount price, List<CancellationPolicy> policies = null) =>
-            new BookedRoom(default, default, price, default, default, default, default, new List<KeyValuePair<string, string>>(), deadline, new List<Pax>(), default);
+            new BookedRoom(default, default, price, default, default, default, default, new List<KeyValuePair<string, string>>(), deadline, new List<Passenger>(), default);
 
 
         private readonly Booking _booking = new Booking{Currency = Currencies.USD};

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/RefundMoneyTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/RefundMoneyTests.cs
@@ -20,9 +20,6 @@ using HappyTravel.Edo.Data.Payments;
 using HappyTravel.Edo.UnitTests.Mocks;
 using HappyTravel.Edo.UnitTests.Utility;
 using HappyTravel.EdoContracts.Accommodations;
-using HappyTravel.EdoContracts.Accommodations.Enums;
-using HappyTravel.EdoContracts.Accommodations.Internals;
-using HappyTravel.EdoContracts.General;
 using HappyTravel.EdoContracts.General.Enums;
 using HappyTravel.Money.Enums;
 using HappyTravel.Money.Models;
@@ -204,10 +201,10 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
             {
                 new BookedRoom(default, default, new MoneyAmount(100m, Currencies.USD), default, default, default, default,
                     new List<KeyValuePair<string, string>>(),
-                    new Deadline(
+                    new Data.Booking.Deadline(
                         new DateTime(2020, 1, 2), 
-                        new List<CancellationPolicy>{new CancellationPolicy(new DateTime(2020, 1, 2), 40d)}),
-                    new EditableList<Pax>(), default)
+                        new List<Data.Booking.CancellationPolicy>{new Data.Booking.CancellationPolicy(new DateTime(2020, 1, 2), 40d)}),
+                    new EditableList<Passenger>(), default)
             }
         };
 


### PR DESCRIPTION
Some data was stored in DB-s jsonb "as is". This can lead to issues:
1. Incorrect deserialization (readonly structs can work wrong on EF deserialize)
2. Broken deserialization when contracts change

I've cloned the models that are used in DB - made separate classes with the same fields and added appropriate conversion from contracts.
For now only enums from contracts should be there, no complex models.