### PR TITLE
Added basic metrics

### DIFF
--- a/Api/Controllers/AgentControllers/AccommodationsController.cs
+++ b/Api/Controllers/AgentControllers/AccommodationsController.cs
@@ -8,6 +8,7 @@ using HappyTravel.Edo.Api.Filters.Authorization.CounterpartyStatesFilters;
 using HappyTravel.Edo.Api.Filters.Authorization.AgentExistingFilters;
 using HappyTravel.Edo.Api.Filters.Authorization.InAgencyPermissionFilters;
 using HappyTravel.Edo.Api.Infrastructure;
+using HappyTravel.Edo.Api.Infrastructure.Metrics;
 using HappyTravel.Edo.Api.Models.Accommodations;
 using HappyTravel.Edo.Api.Models.Agents;
 using HappyTravel.Edo.Api.Models.Availabilities;
@@ -67,6 +68,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         [InAgencyPermissions(InAgencyPermissions.AccommodationAvailabilitySearch)]
         public async Task<IActionResult> StartAvailabilitySearch([FromBody] AvailabilityRequest request)
         {
+            Counters.WideAvailabilitySearchTimes.Inc();
             var agent = await _agentContextService.GetAgent();
             return OkOrBadRequest(await _wideAvailabilitySearchService.StartSearch(request, agent, LanguageCode));
         }

--- a/Api/HappyTravel.Edo.Api.csproj
+++ b/Api/HappyTravel.Edo.Api.csproj
@@ -47,6 +47,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc1.16" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc1.16" />
     <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc1.16" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="4.0.0" />
     <PackageReference Include="Sendgrid" Version="9.21.0" />
     <PackageReference Include="Sentry.AspNetCore" Version="2.1.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />

--- a/Api/Infrastructure/Metrics/Counters.cs
+++ b/Api/Infrastructure/Metrics/Counters.cs
@@ -1,0 +1,13 @@
+using Prometheus;
+
+namespace HappyTravel.Edo.Api.Infrastructure.Metrics
+{
+    public static class Counters
+    {
+        public static Counter WideAvailabilitySearchTimes = Prometheus.Metrics.CreateCounter("availability_search_counter", "Counts starts of the wide availability search",
+            new CounterConfiguration
+            {
+                LabelNames = new[] {"method", "endpoint"},
+            });
+    }
+}

--- a/Api/Infrastructure/Metrics/Counters.cs
+++ b/Api/Infrastructure/Metrics/Counters.cs
@@ -4,7 +4,7 @@ namespace HappyTravel.Edo.Api.Infrastructure.Metrics
 {
     public static class Counters
     {
-        public static Counter WideAvailabilitySearchTimes = Prometheus.Metrics.CreateCounter("availability_search_counter", "Counts starts of the wide availability search",
+        public static readonly Counter WideAvailabilitySearchTimes = Prometheus.Metrics.CreateCounter("availability_search_counter", "Counts starts of the wide availability search",
             new CounterConfiguration
             {
                 LabelNames = new[] {"method", "endpoint"},

--- a/Api/Startup.cs
+++ b/Api/Startup.cs
@@ -30,6 +30,7 @@ using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
+using Prometheus;
 
 namespace HappyTravel.Edo.Api
 {
@@ -164,7 +165,6 @@ namespace HappyTravel.Edo.Api
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
             Infrastructure.Logging.AppLogging.LoggerFactory = loggerFactory;
-
             app.Use(async (context, next) =>
             {
                 if (context.Request.Path.StartsWithSegments("/robots.txt"))
@@ -208,6 +208,8 @@ namespace HappyTravel.Edo.Api
 
             app.UseHealthChecks("/health");
             app.UseRouting()
+                // TODO: Change /prometheus/metrics to default url when ambiguous routes with OData will be fixed
+                .UseMetricServer(url: "/prometheus/metrics")
                 .UseAuthentication()
                 .UseAuthorization()
                 .UseEndpoints(endpoints =>


### PR DESCRIPTION
Added only one straightforward counter, by starts of availability search.
Metrics endpoint is temporarily `/prometheus/metrics`