### PR TITLE
Removed booking request failure flow

### DIFF
--- a/Api/Services/Accommodations/Bookings/BookingRegistrationService.cs
+++ b/Api/Services/Accommodations/Bookings/BookingRegistrationService.cs
@@ -28,8 +28,6 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
             IBookingMailingService bookingMailingService,
             IDateTimeProvider dateTimeProvider,
             IAccountPaymentService accountPaymentService,
-            ISupplierConnectorManager supplierConnectorManager,
-            IBookingPaymentService paymentService,
             IBookingEvaluationStorage bookingEvaluationStorage,
             IBookingPaymentService bookingPaymentService,
             IBookingRequestStorage requestStorage,
@@ -43,8 +41,6 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
             _bookingMailingService = bookingMailingService;
             _dateTimeProvider = dateTimeProvider;
             _accountPaymentService = accountPaymentService;
-            _supplierConnectorManager = supplierConnectorManager;
-            _paymentService = paymentService;
             _bookingEvaluationStorage = bookingEvaluationStorage;
             _bookingPaymentService = bookingPaymentService;
             _requestStorage = requestStorage;

--- a/Api/Services/Accommodations/Bookings/Flows/BookingRequestExecutor.cs
+++ b/Api/Services/Accommodations/Bookings/Flows/BookingRequestExecutor.cs
@@ -25,16 +25,13 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Flows
         }
 
 
-        public Task<Result<Booking>> Execute(AccommodationBookingRequest bookingRequest, string availabilityId, Data.Bookings.Booking booking, string languageCode)
+        public async Task<Booking> Execute(AccommodationBookingRequest bookingRequest, string availabilityId, Data.Bookings.Booking booking, string languageCode)
         {
-            return SendSupplierRequest(bookingRequest, availabilityId, booking, languageCode)
-                .Tap(ProcessResponse);
+            var response = await SendSupplierRequest(bookingRequest, availabilityId, booking, languageCode);
+            await ProcessResponse(response);
+            return response;
             
-
-            Task ProcessResponse(Booking response) => _responseProcessor.ProcessResponse(response, booking);
-
-
-            async Task<Result<EdoContracts.Accommodations.Booking>> SendSupplierRequest(AccommodationBookingRequest bookingRequest, string availabilityId,
+            async Task<EdoContracts.Accommodations.Booking> SendSupplierRequest(AccommodationBookingRequest bookingRequest, string availabilityId,
                 Data.Bookings.Booking booking, string languageCode)
             {
                 var features = new List<Feature>(); //bookingRequest.Features
@@ -92,6 +89,9 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Flows
                         new List<SlimRoomOccupation>(0),
                         BookingUpdateModes.Asynchronous);
             }
+            
+            
+            Task ProcessResponse(Booking response) => _responseProcessor.ProcessResponse(response, booking);
         }
 
 

--- a/Api/Services/Accommodations/Bookings/Flows/IBookingRequestExecutor.cs
+++ b/Api/Services/Accommodations/Bookings/Flows/IBookingRequestExecutor.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Models.Bookings;
 using HappyTravel.EdoContracts.Accommodations;
 
@@ -7,6 +6,6 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Flows
 {
     public interface IBookingRequestExecutor
     {
-        Task<Result<Booking>> Execute(AccommodationBookingRequest bookingRequest, string availabilityId, Data.Bookings.Booking booking, string languageCode);
+        Task<Booking> Execute(AccommodationBookingRequest bookingRequest, string availabilityId, Data.Bookings.Booking booking, string languageCode);
     }
 }


### PR DESCRIPTION
In our current flow booking request execution never fails, it just returns stub results if failed, because we never know whether it failed on our connector side, network or suppliers' API.
Removed all the logic that relied on failed booking request execution - processing of this will be added for administrators