### PR TITLE
Renamed IPaymentService to IPaymentCallbackService and getting refund…

### DIFF
--- a/Api/Controllers/AgentControllers/PaymentsController.cs
+++ b/Api/Controllers/AgentControllers/PaymentsController.cs
@@ -26,11 +26,11 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
     public class PaymentsController : BaseController
     {
         public PaymentsController(IAccountPaymentService accountPaymentService,
-            IBookingPaymentInfoService bookingPaymentInfoService, IPaymentSettingsService paymentSettingsService,
+            IBookingPaymentCallbackService bookingPaymentCallbackService, IPaymentSettingsService paymentSettingsService,
             IAgentContextService agentContextService, ICreditCardPaymentProcessingService creditCardPaymentProcessingService)
         {
             _accountPaymentService = accountPaymentService;
-            _bookingPaymentInfoService = bookingPaymentInfoService;
+            _bookingPaymentCallbackService = bookingPaymentCallbackService;
             _paymentSettingsService = paymentSettingsService;
             _agentContextService = agentContextService;
             _creditCardPaymentProcessingService = creditCardPaymentProcessingService;
@@ -69,7 +69,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
             return OkOrBadRequest(await _creditCardPaymentProcessingService.Authorize(request,
                 LanguageCode,
                 ClientIp,
-                _bookingPaymentInfoService,
+                _bookingPaymentCallbackService,
                 await _agentContextService.GetAgent()));
         }
 
@@ -88,7 +88,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
             return OkOrBadRequest(await _creditCardPaymentProcessingService.Authorize(request,
                 LanguageCode,
                 ClientIp,
-                _bookingPaymentInfoService,
+                _bookingPaymentCallbackService,
                 await _agentContextService.GetAgent()));
         }
 
@@ -103,7 +103,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         [MinCounterpartyState(CounterpartyStates.FullAccess)]
         [InAgencyPermissions(InAgencyPermissions.AccommodationBooking)]
         public async Task<IActionResult> PaymentCallback([FromBody] JObject value)
-            => OkOrBadRequest(await _creditCardPaymentProcessingService.ProcessPaymentResponse(value, _bookingPaymentInfoService));
+            => OkOrBadRequest(await _creditCardPaymentProcessingService.ProcessPaymentResponse(value, _bookingPaymentCallbackService));
 
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         private readonly IAgentContextService _agentContextService;
         private readonly ICreditCardPaymentProcessingService _creditCardPaymentProcessingService;
         private readonly IAccountPaymentService _accountPaymentService;
-        private readonly IBookingPaymentInfoService _bookingPaymentInfoService;
+        private readonly IBookingPaymentCallbackService _bookingPaymentCallbackService;
         private readonly IPaymentSettingsService _paymentSettingsService;
     }
 }

--- a/Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -456,7 +456,7 @@ namespace HappyTravel.Edo.Api.Infrastructure
             services.AddTransient<IBookingOfflinePaymentService, BookingOfflinePaymentService>();
             services.AddTransient<IBookingCreditCardPaymentService, BookingCreditCardPaymentService>();
             services.AddTransient<IBookingAccountPaymentService, BookingAccountPaymentService>();
-            services.AddTransient<IBookingPaymentInfoService, BookingPaymentInfoService>();
+            services.AddTransient<IBookingPaymentCallbackService, BookingPaymentCallbackService>();
             
             
             services.AddTransient<IAccommodationService, AccommodationService>();

--- a/Api/Services/Accommodations/Bookings/Payments/BookingAccountPaymentService.cs
+++ b/Api/Services/Accommodations/Bookings/Payments/BookingAccountPaymentService.cs
@@ -18,14 +18,14 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Payments
     {
         public BookingAccountPaymentService(IAccountPaymentService accountPaymentService,
             IBookingDocumentsService documentsService,
-            IBookingPaymentInfoService paymentInfoService,
+            IBookingPaymentCallbackService paymentCallbackService,
             ILogger<BookingAccountPaymentService> logger,
             EdoContext context,
             IBookingDocumentsMailingService documentsMailingService)
         {
             _accountPaymentService = accountPaymentService;
             _documentsService = documentsService;
-            _paymentInfoService = paymentInfoService;
+            _paymentCallbackService = paymentCallbackService;
             _logger = logger;
             _context = context;
             _documentsMailingService = documentsMailingService;
@@ -38,7 +38,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Payments
                 return Result.Success();
 
             var reason = $"Refunding money for booking {booking.ReferenceCode}";
-            return await _accountPaymentService.Refund(booking.ReferenceCode, user, _paymentInfoService, reason);
+            return await _accountPaymentService.Refund(booking.ReferenceCode, user, _paymentCallbackService, reason);
         }
 
         
@@ -59,7 +59,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Payments
 
             async Task<Result<string>> Charge()
             {
-                var (_, isFailure, _, error) = await _accountPaymentService.Charge(booking.ReferenceCode, user, _paymentInfoService);
+                var (_, isFailure, _, error) = await _accountPaymentService.Charge(booking.ReferenceCode, user, _paymentCallbackService);
                 if (isFailure)
                     return Result.Failure<string>($"Unable to charge payment for a booking with reference code: '{booking.ReferenceCode}'. " +
                         $"Error while charging: {error}");
@@ -96,7 +96,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Payments
         
         private readonly IAccountPaymentService _accountPaymentService;
         private readonly IBookingDocumentsService _documentsService;
-        private readonly IBookingPaymentInfoService _paymentInfoService;
+        private readonly IBookingPaymentCallbackService _paymentCallbackService;
         private readonly ILogger<BookingAccountPaymentService> _logger;
         private readonly EdoContext _context;
         private readonly IBookingDocumentsMailingService _documentsMailingService;

--- a/Api/Services/Accommodations/Bookings/Payments/IBookingPaymentCallbackService.cs
+++ b/Api/Services/Accommodations/Bookings/Payments/IBookingPaymentCallbackService.cs
@@ -2,6 +2,6 @@ using HappyTravel.Edo.Api.Services.Payments;
 
 namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Payments
 {
-    public interface IBookingPaymentInfoService : IPaymentsService
+    public interface IBookingPaymentCallbackService : IPaymentCallbackService
     { }
 }

--- a/Api/Services/Payments/Accounts/AccountPaymentService.cs
+++ b/Api/Services/Payments/Accounts/AccountPaymentService.cs
@@ -52,7 +52,7 @@ namespace HappyTravel.Edo.Api.Services.Payments.Accounts
         }
 
 
-        public async Task<Result> Refund(string referenceCode, UserInfo user, IPaymentsService paymentsService, string reason)
+        public async Task<Result> Refund(string referenceCode, UserInfo user, IPaymentCallbackService paymentCallbackService, string reason)
         {
             return await GetChargingAccountId()
                 .Bind(GetRefundableAmount)
@@ -61,12 +61,12 @@ namespace HappyTravel.Edo.Api.Services.Payments.Accounts
 
             
             Task<Result<int>> GetChargingAccountId() 
-                => paymentsService.GetChargingAccountId(referenceCode);
+                => paymentCallbackService.GetChargingAccountId(referenceCode);
             
             
             async Task<Result<(int accountId, MoneyAmount)>> GetRefundableAmount(int accountId)
             {
-                var (_, isFailure, refundableAmount, error) = await paymentsService.GetRefundableAmount(referenceCode);
+                var (_, isFailure, refundableAmount, error) = await paymentCallbackService.GetRefundableAmount(referenceCode);
                 if (isFailure)
                     return Result.Failure<(int, MoneyAmount)>(error);
 
@@ -104,11 +104,11 @@ namespace HappyTravel.Edo.Api.Services.Payments.Accounts
             
             
             Task<Result> ProcessPaymentResults(Payment payment) 
-                => paymentsService.ProcessPaymentChanges(payment);
+                => paymentCallbackService.ProcessPaymentChanges(payment);
         }
 
 
-        public async Task<Result<PaymentResponse>> Charge(string referenceCode, UserInfo user, IPaymentsService paymentsService)
+        public async Task<Result<PaymentResponse>> Charge(string referenceCode, UserInfo user, IPaymentCallbackService paymentCallbackService)
         {
             return await GetChargingAccount()
                 .Bind(GetChargingAmount)
@@ -119,12 +119,12 @@ namespace HappyTravel.Edo.Api.Services.Payments.Accounts
 
             
             Task<Result<int>> GetChargingAccount() 
-                => paymentsService.GetChargingAccountId(referenceCode);
+                => paymentCallbackService.GetChargingAccountId(referenceCode);
             
             
             async Task<Result<(int, MoneyAmount)>> GetChargingAmount(int accountId)
             {
-                var (_, isFailure, amount, error) = await paymentsService.GetServicePrice(referenceCode);
+                var (_, isFailure, amount, error) = await paymentCallbackService.GetServicePrice(referenceCode);
                 if (isFailure)
                     return Result.Failure<(int, MoneyAmount)>(error);
 
@@ -175,7 +175,7 @@ namespace HappyTravel.Edo.Api.Services.Payments.Accounts
 
 
             Task<Result> ProcessPaymentResults(Payment payment) 
-                => paymentsService.ProcessPaymentChanges(payment);
+                => paymentCallbackService.ProcessPaymentChanges(payment);
 
             
             PaymentResponse CreateResult() 

--- a/Api/Services/Payments/Accounts/IAccountPaymentService.cs
+++ b/Api/Services/Payments/Accounts/IAccountPaymentService.cs
@@ -13,8 +13,8 @@ namespace HappyTravel.Edo.Api.Services.Payments.Accounts
         Task<bool> CanPayWithAccount(AgentContext agentContext);
         Task<Result<AccountBalanceInfo>> GetAccountBalance(Currencies currency, AgentContext agent);
         Task<Result<AccountBalanceInfo>> GetAccountBalance(Currencies currency, int agencyId);
-        Task<Result<PaymentResponse>> Charge(string referenceCode, UserInfo user, IPaymentsService paymentsService);
-        Task<Result> Refund(string referenceCode, UserInfo user, IPaymentsService paymentsService, string reason);
+        Task<Result<PaymentResponse>> Charge(string referenceCode, UserInfo user, IPaymentCallbackService paymentCallbackService);
+        Task<Result> Refund(string referenceCode, UserInfo user, IPaymentCallbackService paymentCallbackService, string reason);
         Task<Result> TransferToChildAgency(int payerAccountId, int recipientAccountId, MoneyAmount amount, AgentContext agent);
     }
 }

--- a/Api/Services/Payments/CreditCards/ICreditCardPaymentProcessingService.cs
+++ b/Api/Services/Payments/CreditCards/ICreditCardPaymentProcessingService.cs
@@ -11,19 +11,19 @@ namespace HappyTravel.Edo.Api.Services.Payments.CreditCards
     public interface ICreditCardPaymentProcessingService
     {
         Task<Result<PaymentResponse>> Authorize(NewCreditCardPaymentRequest request, 
-            string languageCode, string ipAddress, IPaymentsService paymentsService, AgentContext agent);
+            string languageCode, string ipAddress, IPaymentCallbackService paymentCallbackService, AgentContext agent);
 
 
         Task<Result<PaymentResponse>> Authorize(SavedCreditCardPaymentRequest request, string languageCode, 
-            string ipAddress, IPaymentsService paymentsService, AgentContext agent);
+            string ipAddress, IPaymentCallbackService paymentCallbackService, AgentContext agent);
 
 
-        Task<Result<PaymentResponse>> ProcessPaymentResponse(JObject rawResponse, IPaymentsService paymentsService);
+        Task<Result<PaymentResponse>> ProcessPaymentResponse(JObject rawResponse, IPaymentCallbackService paymentCallbackService);
 
-        Task<Result<string>> CaptureMoney(string referenceCode, UserInfo user, IPaymentsService paymentsService);
+        Task<Result<string>> CaptureMoney(string referenceCode, UserInfo user, IPaymentCallbackService paymentCallbackService);
 
-        Task<Result> VoidMoney(string referenceCode, UserInfo user, IPaymentsService paymentsService);
+        Task<Result> VoidMoney(string referenceCode, UserInfo user, IPaymentCallbackService paymentCallbackService);
 
-        Task<Result> RefundMoney(string referenceCode, MoneyAmount refundingAmount, UserInfo user, IPaymentsService paymentsService);
+        Task<Result> RefundMoney(string referenceCode, UserInfo user, IPaymentCallbackService paymentCallbackService);
     }
 }

--- a/Api/Services/Payments/External/PaymentCallbackDispatcher.cs
+++ b/Api/Services/Payments/External/PaymentCallbackDispatcher.cs
@@ -18,14 +18,14 @@ namespace HappyTravel.Edo.Api.Services.Payments.External
     {
         public PaymentCallbackDispatcher(ICreditCardPaymentProcessingService creditCardPaymentProcessingService,
             IPayfortResponseParser responseParser,
-            IBookingPaymentInfoService bookingPaymentInfoService,
+            IBookingPaymentCallbackService bookingPaymentCallbackService,
             IPaymentLinksProcessingService linksProcessingService,
             ITagProcessor tagProcessor,
             EdoContext context)
         {
             _creditCardPaymentProcessingService = creditCardPaymentProcessingService;
             _responseParser = responseParser;
-            _bookingPaymentInfoService = bookingPaymentInfoService;
+            _bookingPaymentCallbackService = bookingPaymentCallbackService;
             _linksProcessingService = linksProcessingService;
             _tagProcessor = tagProcessor;
             _context = context;
@@ -48,7 +48,7 @@ namespace HappyTravel.Edo.Api.Services.Payments.External
 
             // We have no information about where this callback from: internal (authorized customer payment) or external (payment links).
             // So we'll try to process callback sequentially with different services and return first successful result (or fail).
-            var internalPaymentProcessResult = await _creditCardPaymentProcessingService.ProcessPaymentResponse(response, _bookingPaymentInfoService);
+            var internalPaymentProcessResult = await _creditCardPaymentProcessingService.ProcessPaymentResponse(response, _bookingPaymentCallbackService);
             if (internalPaymentProcessResult.IsSuccess)
                 return internalPaymentProcessResult;
 
@@ -69,7 +69,7 @@ namespace HappyTravel.Edo.Api.Services.Payments.External
         private readonly EdoContext _context;
         private readonly ICreditCardPaymentProcessingService _creditCardPaymentProcessingService;
         private readonly IPayfortResponseParser _responseParser;
-        private readonly IBookingPaymentInfoService _bookingPaymentInfoService;
+        private readonly IBookingPaymentCallbackService _bookingPaymentCallbackService;
         private readonly IPaymentLinksProcessingService _linksProcessingService;
 
         private readonly ITagProcessor _tagProcessor;

--- a/Api/Services/Payments/IPaymentCallbackService.cs
+++ b/Api/Services/Payments/IPaymentCallbackService.cs
@@ -5,7 +5,7 @@ using HappyTravel.Money.Models;
 
 namespace HappyTravel.Edo.Api.Services.Payments
 {
-    public interface IPaymentsService
+    public interface IPaymentCallbackService
     {
         Task<Result<MoneyAmount>> GetServicePrice(string referenceCode);
 

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/ChargeMoneyTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/ChargeMoneyTests.cs
@@ -95,9 +95,9 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
             Assert.True(isSuccess);
             paymentServiceMock.Verify(p=>p.ProcessPaymentChanges(It.IsAny<Payment>()), Times.Once);
             
-            Mock<IPaymentsService> CreatePaymentServiceMock()
+            Mock<IPaymentCallbackService> CreatePaymentServiceMock()
             {
-                var paymentServiceMock = new Mock<IPaymentsService>();
+                var paymentServiceMock = new Mock<IPaymentCallbackService>();
                 paymentServiceMock.Setup(p => p.GetChargingAccountId(It.IsAny<string>()))
                     .ReturnsAsync(_account.Id);
 
@@ -162,9 +162,9 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         
             Assert.True(isFailure);
             
-            IPaymentsService CreatePaymentServiceWithoutServicePrice()
+            IPaymentCallbackService CreatePaymentServiceWithoutServicePrice()
             {
-                var paymentServiceMock = new Mock<IPaymentsService>();
+                var paymentServiceMock = new Mock<IPaymentCallbackService>();
 
                 paymentServiceMock.Setup(p => p.GetServicePrice(It.IsAny<string>()))
                     .ReturnsAsync(Result.Failure<MoneyAmount>("Could not get service price"));
@@ -184,9 +184,9 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
             Assert.True(isFailure);
             
             
-            IPaymentsService CreatePaymentServiceWithoutAgencyAccount()
+            IPaymentCallbackService CreatePaymentServiceWithoutAgencyAccount()
             {
-                var paymentServiceMock = new Mock<IPaymentsService>();
+                var paymentServiceMock = new Mock<IPaymentCallbackService>();
 
                 paymentServiceMock.Setup(p => p.GetServicePrice(It.IsAny<string>()))
                     .ReturnsAsync(new MoneyAmount());
@@ -199,9 +199,9 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         }
         
         
-        private IPaymentsService CreatePaymentServiceWithMoneyAmount(MoneyAmount moneyAmount)
+        private IPaymentCallbackService CreatePaymentServiceWithMoneyAmount(MoneyAmount moneyAmount)
         {
-            var paymentServiceMock = new Mock<IPaymentsService>();
+            var paymentServiceMock = new Mock<IPaymentCallbackService>();
             paymentServiceMock.Setup(p => p.GetChargingAccountId(It.IsAny<string>()))
                 .ReturnsAsync(_account.Id);
 

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/RefundMoneyTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/RefundMoneyTests.cs
@@ -111,9 +111,9 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
             Assert.Equal(1000m, _account.Balance);
             
             
-            IPaymentsService CreatePaymentServiceWithInvalidAccount()
+            IPaymentCallbackService CreatePaymentServiceWithInvalidAccount()
             {
-                var paymentServiceMock = new Mock<IPaymentsService>();
+                var paymentServiceMock = new Mock<IPaymentCallbackService>();
                 paymentServiceMock.Setup(p => p.GetChargingAccountId(It.IsAny<string>()))
                     .ReturnsAsync(Result.Failure<int>("Could not get agency account"));
 
@@ -143,9 +143,9 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         
         
         
-        private IPaymentsService CreatePaymentServiceWithRefundableAmount(MoneyAmount moneyAmount)
+        private IPaymentCallbackService CreatePaymentServiceWithRefundableAmount(MoneyAmount moneyAmount)
         {
-            var paymentServiceMock = new Mock<IPaymentsService>();
+            var paymentServiceMock = new Mock<IPaymentCallbackService>();
             paymentServiceMock.Setup(p => p.GetChargingAccountId(It.IsAny<string>()))
                 .ReturnsAsync(_account.Id);
 


### PR DESCRIPTION
…able amount from the service in both flows - credit and account

1. The next step of refactoring - renamed IPaymentService to IPaymentCallbackService since it provides callbacks for payment changes
2. Getting refundable amount from the BookingPaymentCallbackService - for credit cards too (previously this worked only for account payments)
3. Refundable amount is set to full when booking state is rejected or reverted. These statuses are used for situations when we are not charged any money from suppliers