### PR TITLE
Fixed query data

### DIFF
--- a/Api/Services/Accommodations/Bookings/Mailing/BookingReportsService.cs
+++ b/Api/Services/Accommodations/Bookings/Mailing/BookingReportsService.cs
@@ -255,7 +255,6 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Mailing
 
         private static readonly HashSet<BookingStatuses> BookingStatusesForSummary = new()
         {
-            BookingStatuses.InternalProcessing,
             BookingStatuses.WaitingForResponse,
             BookingStatuses.Pending,
             BookingStatuses.Confirmed,


### PR DESCRIPTION
Now only bookings with the required statuses are included in the report. The period of 5 days is counted from the moment the report is generated.