### PR TITLE
Return ProblemDetails instead of string in BadRequest responses

### DIFF
--- a/Api/Controllers/AdministratorControllers/BookingsController.cs
+++ b/Api/Controllers/AdministratorControllers/BookingsController.cs
@@ -99,7 +99,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
             var (_, _, admin, _) = await _administratorContext.GetCurrent();
             var (_, isFailure, error) = await _bookingManagementService.Discard(bookingId, admin);
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return NoContent();
         } 
@@ -120,7 +120,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
             var (_, _, admin, _) = await _administratorContext.GetCurrent();
             var (_, isFailure, error) = await _bookingManagementService.Cancel(bookingId, admin, requireSupplierConfirmation);
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return NoContent();
         }

--- a/Api/Controllers/AdministratorControllers/PaymentsController.cs
+++ b/Api/Controllers/AdministratorControllers/PaymentsController.cs
@@ -66,7 +66,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
 
             return isSuccess
                 ? NoContent()
-                : (IActionResult) BadRequest(error);
+                : (IActionResult) BadRequest(ProblemDetailsBuilder.Build(error));
         }
 
 

--- a/Api/Controllers/AgentControllers/AgentsController.cs
+++ b/Api/Controllers/AgentControllers/AgentsController.cs
@@ -139,7 +139,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
             var agent = await _agentContextService.GetAgent();
             var (_, isFailure, error) = await _agentInvitationService.Resend(invitationCode, agent);
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return NoContent();
         }

--- a/Api/Controllers/AgentControllers/AvailabilitiesController.cs
+++ b/Api/Controllers/AgentControllers/AvailabilitiesController.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Filters.Authorization.CounterpartyStatesFilters;
 using HappyTravel.Edo.Api.Filters.Authorization.InAgencyPermissionFilters;
+using HappyTravel.Edo.Api.Infrastructure;
 using HappyTravel.Edo.Api.Infrastructure.Metrics;
 using HappyTravel.Edo.Api.Models.Accommodations;
 using HappyTravel.Edo.Api.Models.Availabilities;
@@ -112,7 +113,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         {
             var (_, isFailure, response, error) = await _roomSelectionService.GetState(searchId, resultId, await _agentContextService.GetAgent());
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return Ok(response);
         }
@@ -138,7 +139,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
             
             var (_, isFailure, response, error) = await _roomSelectionService.Get(searchId, resultId, await _agentContextService.GetAgent(), LanguageCode);
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return Ok(response);
         }

--- a/Api/Controllers/AgentControllers/BookingResponseController.cs
+++ b/Api/Controllers/AgentControllers/BookingResponseController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Infrastructure;
 using HappyTravel.Edo.Api.Infrastructure.Http;
 using HappyTravel.Edo.Api.Services.SupplierResponses;
 using HappyTravel.Edo.Common.Enums;
@@ -42,8 +43,8 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
             
             var (_, isFailure, error) = await _netstormingResponseService.ProcessBookingDetailsResponse(xmlRequestData);
             if (isFailure)
-                return BadRequest(error);
-            
+                return BadRequest(ProblemDetailsBuilder.Build(error));
+
             return Ok();
         }
 

--- a/Api/Controllers/AgentControllers/BookingSupportingDocumentsController.cs
+++ b/Api/Controllers/AgentControllers/BookingSupportingDocumentsController.cs
@@ -108,7 +108,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
             var agent = await _agentContextService.GetAgent();
             var (_, isFailure, document, error) = await _bookingDocumentsService.GetActualInvoice(bookingId, agent.AgentId);
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             var (regData, invoice) = document;
             return Ok(new BookingDocument<BookingInvoiceData>(regData.Number, regData.Date, invoice));

--- a/Api/Controllers/AgentControllers/BookingsController.cs
+++ b/Api/Controllers/AgentControllers/BookingsController.cs
@@ -62,7 +62,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         {
             var (_, isFailure, refCode, error) = await _bankCreditCardBookingFlow.Register(request, await _agentContextService.GetAgent(), LanguageCode);
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return Ok(refCode);
         }
@@ -83,7 +83,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
             var (_, isFailure, bookingInfo, error) = await _financialAccountBookingFlow.BookByAccount(request, await _agentContextService.GetAgent(),
                 LanguageCode, ClientIp);
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return Ok(bookingInfo);
         }
@@ -105,7 +105,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
             var agent = await _agentContextService.GetAgent();
             var (_, isFailure, bookingDetails, error) = await _bankCreditCardBookingFlow.Finalize(referenceCode, agent, LanguageCode);
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return Ok(bookingDetails);
         }
@@ -126,7 +126,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
             var agent = await _agentContextService.GetAgent();
             var (_, isFailure, error) = await _bookingManagementService.RefreshStatus(bookingId, agent);
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return Ok();
         }
@@ -147,7 +147,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
             var agent = await _agentContextService.GetAgent();
             var (_, isFailure, error) = await _bookingManagementService.Cancel(bookingId, agent);
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return NoContent();
         }
@@ -168,7 +168,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
             var agent = await _agentContextService.GetAgent();
             var (_, isFailure, error) = await _bookingManagementService.Cancel(referenceCode, agent);
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return NoContent();
         }
@@ -189,7 +189,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
                 await _bookingInfoService.GetAgentAccommodationBookingInfo(bookingId, await _agentContextService.GetAgent(), LanguageCode);
 
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return Ok(bookingData);
         }
@@ -210,7 +210,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
                 await _bookingInfoService.GetAgentAccommodationBookingInfo(referenceCode, await _agentContextService.GetAgent(), LanguageCode);
 
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return Ok(bookingData);
         }
@@ -229,7 +229,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
             var (_, isFailure, error) = await _creditCardPaymentService.PayForAccountBooking(referenceCode, await _agentContextService.GetAgent());
             
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return NoContent();
         }
@@ -251,7 +251,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
                 await _bookingRecordManager.Get(bookingId, agent.AgentId);
 
             if (isFailure)
-                return BadRequest(error);
+                return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return Ok(BookingCancellationPenaltyCalculator.Calculate(booking, _dateTimeProvider.UtcNow()));
         }

--- a/Api/Controllers/AgentControllers/ExternalPaymentsController.cs
+++ b/Api/Controllers/AgentControllers/ExternalPaymentsController.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using HappyTravel.Edo.Api.Infrastructure;
 using HappyTravel.Edo.Api.Models.Payments;
 using HappyTravel.Edo.Api.Services.Payments.External;
 using Microsoft.AspNetCore.Authorization;
@@ -31,7 +32,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         public async Task<IActionResult> PaymentCallback([FromForm] IFormCollection form)
         {
             if (form is null)
-                return BadRequest("Payment data is required");
+                return BadRequest(ProblemDetailsBuilder.Build("Payment data is required"));
 
             var dictionary = form.ToDictionary(k => k.Key, k => WebUtility.UrlDecode(k.Value.ToString()));
             var value = JObject.FromObject(dictionary);

--- a/Api/Controllers/AgentControllers/InternalBookingsController.cs
+++ b/Api/Controllers/AgentControllers/InternalBookingsController.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Filters.Authorization.ServiceAccountFilters;
+using HappyTravel.Edo.Api.Infrastructure;
 using HappyTravel.Edo.Api.Models.Bookings;
 using HappyTravel.Edo.Api.Models.Markups;
 using HappyTravel.Edo.Api.Models.Users;
@@ -78,7 +79,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         public async Task<IActionResult> GetBookingsForCapture(DateTime? date)
         {
             if (!date.HasValue)
-                return BadRequest($"Date should be specified");
+                return BadRequest(ProblemDetailsBuilder.Build($"Date should be specified"));
             
             return Ok(await _bookingsProcessingService.GetForCapture(date.Value));
         }
@@ -112,7 +113,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         public async Task<IActionResult> GetBookingsForCharge(DateTime? date)
         {
             if (!date.HasValue)
-                return BadRequest($"Date should be specified");
+                return BadRequest(ProblemDetailsBuilder.Build($"Date should be specified"));
             
             return Ok(await _bookingsProcessingService.GetForCharge(date.Value));
         }
@@ -146,7 +147,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         public async Task<IActionResult> GetBookingsToNotify(DateTime? date)
         {
             if (!date.HasValue)
-                return BadRequest($"Date should be specified");
+                return BadRequest(ProblemDetailsBuilder.Build($"Date should be specified"));
             
             return Ok(await _bookingsProcessingService.GetForNotification(date.Value));
         }
@@ -220,7 +221,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         public async Task<IActionResult> GetAppliedMarkupsForMaterialization(DateTime? date)
         {
             if (!date.HasValue)
-                return BadRequest($"Date should be specified");
+                return BadRequest(ProblemDetailsBuilder.Build($"Date should be specified"));
             
             return Ok(await _markupBonusMaterializationService.GetForMaterialize(date.Value));
         }


### PR DESCRIPTION
Envelope error string into ProblemDetails where plane string was returned in BadRequest response.