### PR TITLE
Technical/nijo 1322 add agency id to agent markup2

### DIFF
--- a/Api/AdministratorServices/AgentService.cs
+++ b/Api/AdministratorServices/AgentService.cs
@@ -37,8 +37,8 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                        Name = name,
                        Created = created,
                        IsActive = relation.IsActive,
-                       MarkupSettings = (agent.DisplayedMarkupFormula != null)
-                           ? agent.DisplayedMarkupFormula
+                       MarkupSettings = !string.IsNullOrWhiteSpace(relation.DisplayedMarkupFormula)
+                           ? relation.DisplayedMarkupFormula
                            : string.Empty
                    };
 

--- a/Api/Controllers/AgentControllers/AgentMarkupsController.cs
+++ b/Api/Controllers/AgentControllers/AgentMarkupsController.cs
@@ -111,7 +111,8 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         [ProducesResponseType(typeof(List<MarkupInfo>), (int) HttpStatusCode.NoContent)]
         public async Task<IActionResult> GetPolicies(int agentId)
         {
-            return Ok(await _policyManager.Get(agentId));
+            var agencyId = (await _agentContext.GetAgent()).AgencyId;
+            return Ok(await _policyManager.Get(agentId, agencyId));
         }
 
 

--- a/Api/Controllers/AgentControllers/AgentMarkupsController.cs
+++ b/Api/Controllers/AgentControllers/AgentMarkupsController.cs
@@ -108,7 +108,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         /// <param name="agentId">Agent id</param>
         /// <returns></returns>
         [HttpGet("agency/agents/{agentId}/markups")]
-        [ProducesResponseType(typeof(List<MarkupInfo>), (int) HttpStatusCode.NoContent)]
+        [ProducesResponseType(typeof(List<MarkupInfo>), (int) HttpStatusCode.OK)]
         public async Task<IActionResult> GetPolicies(int agentId)
         {
             var agencyId = (await _agentContext.GetAgent()).AgencyId;

--- a/Api/Models/Markups/MarkupPolicyScope.cs
+++ b/Api/Models/Markups/MarkupPolicyScope.cs
@@ -30,6 +30,14 @@ namespace HappyTravel.Edo.Api.Models.Markups
                     .WithMessage("AgencyId is required");
                 v.RuleFor(s => s.AgentId).NotEmpty().When(t => t.Type == MarkupPolicyScopeType.Agent)
                     .WithMessage("AgentId is required");
+
+                v.RuleFor(s => s.CounterpartyId).Empty().When(t => t.Type != MarkupPolicyScopeType.Counterparty)
+                    .WithMessage("CounterpartyId must be empty");
+                v.RuleFor(s => s.AgencyId).Empty()
+                    .When(t => t.Type != MarkupPolicyScopeType.Agency && t.Type != MarkupPolicyScopeType.Agent)
+                    .WithMessage("AgencyId must be empty");
+                v.RuleFor(s => s.AgentId).Empty().When(t => t.Type != MarkupPolicyScopeType.Agent)
+                    .WithMessage("AgentId must be empty");
             }, this);
         }
 

--- a/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationService.cs
+++ b/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationService.cs
@@ -93,7 +93,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                     var markupAmount = appliedMarkup.After.Value.RoomContractSet.Rate.FinalPrice - appliedMarkup.Before.Value.RoomContractSet.Rate.FinalPrice;
                     var policy = appliedMarkup.Policy;
                     appliedMarkups.Add(new AppliedMarkup(
-                        scope: new MarkupPolicyScope(policy.ScopeType, policy.AgentId ?? policy.AgencyId ?? policy.CounterpartyId),
+                        scope: new MarkupPolicyScope(policy.ScopeType, policy.CounterpartyId, policy.AgencyId, policy.AgentId),
                         policyId: policy.Id,
                         amountChange: markupAmount
                     ));

--- a/Api/Services/Agents/AgentService.cs
+++ b/Api/Services/Agents/AgentService.cs
@@ -80,6 +80,7 @@ namespace HappyTravel.Edo.Api.Services.Agents
             return newInfo;
         }
 
+
         public  IQueryable<SlimAgentInfo> GetAgents(AgentContext agentContext)
         {
             var relations = _context.AgentAgencyRelations
@@ -97,8 +98,8 @@ namespace HappyTravel.Edo.Api.Services.Agents
                     Name = name,
                     Created = created,
                     IsActive = relation.IsActive,
-                    MarkupSettings = canObserveMarkups && agent.DisplayedMarkupFormula != null
-                        ? agent.DisplayedMarkupFormula
+                    MarkupSettings = canObserveMarkups && !string.IsNullOrWhiteSpace(relation.DisplayedMarkupFormula)
+                        ? relation.DisplayedMarkupFormula
                         : string.Empty
                 };
         }

--- a/Api/Services/Markups/AdminMarkupPolicyManager.cs
+++ b/Api/Services/Markups/AdminMarkupPolicyManager.cs
@@ -216,7 +216,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
         private Task<Result> UpdateDisplayedMarkupFormula(MarkupPolicy policy)
         {
             return policy.AgentId.HasValue
-                ? _displayedMarkupFormulaService.Update(policy.AgentId.Value)
+                ? _displayedMarkupFormulaService.Update(policy.AgentId.Value, policy.AgencyId.Value)
                 : Task.FromResult(Result.Success());
         }
 

--- a/Api/Services/Markups/AdminMarkupPolicyManager.cs
+++ b/Api/Services/Markups/AdminMarkupPolicyManager.cs
@@ -5,7 +5,11 @@ using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Infrastructure;
 using HappyTravel.Edo.Api.Infrastructure.FunctionalExtensions;
 using HappyTravel.Edo.Api.Models.Markups;
+using HappyTravel.Edo.Api.Models.Markups.AuditEvents;
+using HappyTravel.Edo.Api.Models.Users;
+using HappyTravel.Edo.Api.Services.Management;
 using HappyTravel.Edo.Api.Services.Markups.Templates;
+using HappyTravel.Edo.Common.Enums;
 using HappyTravel.Edo.Common.Enums.Markup;
 using HappyTravel.Edo.Data;
 using HappyTravel.Edo.Data.Markup;
@@ -18,19 +22,24 @@ namespace HappyTravel.Edo.Api.Services.Markups
         public AdminMarkupPolicyManager(EdoContext context,
             IMarkupPolicyTemplateService templateService,
             IDateTimeProvider dateTimeProvider,
-            IDisplayedMarkupFormulaService displayedMarkupFormulaService)
+            IDisplayedMarkupFormulaService displayedMarkupFormulaService,
+            IAdministratorContext administratorContext,
+            IMarkupPolicyAuditService markupPolicyAuditService)
         {
             _context = context;
             _templateService = templateService;
             _dateTimeProvider = dateTimeProvider;;
             _displayedMarkupFormulaService = displayedMarkupFormulaService;
+            _administratorContext = administratorContext;
+            _markupPolicyAuditService = markupPolicyAuditService;
         }
         
         
         public async Task<Result> Add(MarkupPolicyData policyData)
         {
             var (_, isFailure, markupPolicy, error) = await ValidatePolicy(policyData)
-                .Map(SavePolicy);
+                .Map(SavePolicy)
+                .Tap(p => WriteAuditLog(p, MarkupPolicyEventType.AgentMarkupCreated));
 
             if (isFailure)
                 return Result.Failure(error);
@@ -71,7 +80,8 @@ namespace HappyTravel.Edo.Api.Services.Markups
         public async Task<Result> Remove(int policyId)
         {
             var (_, isFailure, markupPolicy, error) = await GetPolicy()
-                .Map(DeletePolicy);
+                .Map(DeletePolicy)
+                .Tap(p => WriteAuditLog(p, MarkupPolicyEventType.AgentMarkupDeleted));
 
             if (isFailure)
                 return Result.Failure(error);
@@ -106,7 +116,8 @@ namespace HappyTravel.Edo.Api.Services.Markups
                 return Result.Failure("Could not find policy");
 
             var (_, isFailure, markupPolicy, error) = await ValidateSettings()
-                .Bind(UpdatePolicy);
+                .Bind(UpdatePolicy)
+                .Tap(p => WriteAuditLog(p, MarkupPolicyEventType.AgentMarkupUpdated));
 
             if (isFailure)
                 return Result.Failure(error);
@@ -185,19 +196,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
             Result ValidateTemplate() => _templateService.Validate(policyData.Settings.TemplateId, policyData.Settings.TemplateSettings);
 
 
-            bool ScopeIsValid()
-            {
-                var (type, counterpartyId, _, _) = policyData.Scope;
-                return type switch
-                {
-                    MarkupPolicyScopeType.Global => counterpartyId == null,
-                    MarkupPolicyScopeType.Counterparty => counterpartyId != null,
-                    MarkupPolicyScopeType.Agency => counterpartyId != null,
-                    MarkupPolicyScopeType.Agent => counterpartyId != null,
-                    MarkupPolicyScopeType.EndClient => counterpartyId != null,
-                    _ => false
-                };
-            }
+            bool ScopeIsValid() => policyData.Scope.Validate().IsSuccess;
 
 
             bool TargetIsValid() => policyData.Target != MarkupPolicyTarget.NotSpecified;
@@ -223,11 +222,27 @@ namespace HappyTravel.Edo.Api.Services.Markups
 
         private static bool IsUpdateUpdateDisplayedMarkupFormulaNeeded(MarkupPolicy policy)
             => policy.ScopeType == MarkupPolicyScopeType.Agent;
-        
+
+
+        private async Task WriteAuditLog(MarkupPolicy policy, MarkupPolicyEventType markupPolicyEventType)
+        {
+            // currently logging only for agents
+            if (policy.ScopeType != MarkupPolicyScopeType.Agent)
+                return;
+
+            var (_, _, administrator, _) = await _administratorContext.GetCurrent();
+
+            await _markupPolicyAuditService.Write(markupPolicyEventType,
+                new AgentMarkupPolicyData(policy.Id, policy.AgentId.Value, policy.AgencyId.Value),
+                administrator.ToUserInfo());
+        }
+
 
         private readonly IMarkupPolicyTemplateService _templateService;
         private readonly EdoContext _context;
         private readonly IDateTimeProvider _dateTimeProvider;
         private readonly IDisplayedMarkupFormulaService _displayedMarkupFormulaService;
+        private readonly IAdministratorContext _administratorContext;
+        private readonly IMarkupPolicyAuditService _markupPolicyAuditService;
     }
 }

--- a/Api/Services/Markups/AgentMarkupPolicyManager.cs
+++ b/Api/Services/Markups/AgentMarkupPolicyManager.cs
@@ -35,7 +35,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
 
         public Task<Result> Add(int agentId, MarkupPolicySettings settings, AgentContext agent)
         {
-            return ValidateSettings(agentId, settings)
+            return ValidateSettings(agentId, agent.AgencyId, settings)
                 .Bind(() => GetAgentAgencyRelation(agentId, agent.AgencyId))
                 .Map(SavePolicy)
                 .Tap(WriteAuditLog)
@@ -52,7 +52,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
                     Order = settings.Order,
                     ScopeType = MarkupPolicyScopeType.Agent,
                     Target = MarkupPolicyTarget.AccommodationAvailability,
-                    AgencyId = null,
+                    AgencyId = agentAgencyRelation.AgencyId,
                     CounterpartyId = null,
                     AgentId = agentAgencyRelation.AgentId,
                     TemplateSettings = settings.TemplateSettings,
@@ -70,7 +70,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
 
             Task WriteAuditLog(MarkupPolicy policy)
                 => _markupPolicyAuditService.Write(MarkupPolicyEventType.AgentMarkupCreated,
-                    new AgentMarkupPolicyData(policy.Id, agentId, default),  // TODO: agencyId should be filled in here and below
+                    new AgentMarkupPolicyData(policy.Id, policy.AgentId.Value, policy.AgencyId.Value),
                     agent.ToUserInfo());
         }
 
@@ -97,7 +97,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
 
             Task WriteAuditLog(MarkupPolicy policy)
                 => _markupPolicyAuditService.Write(MarkupPolicyEventType.AgentMarkupDeleted,
-                    new AgentMarkupPolicyData(policy.Id, agentId, default),
+                    new AgentMarkupPolicyData(policy.Id, policy.AgentId.Value, policy.AgencyId.Value),
                     agent.ToUserInfo());
         }
 
@@ -106,7 +106,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
         {
             return await GetAgentAgencyRelation(agentId, agent.AgencyId) 
                 .Bind(GetPolicy)
-                .Check(_ => ValidateSettings(agentId, settings, policyId))
+                .Check(_ => ValidateSettings(agentId, agent.AgencyId, settings, policyId))
                 .Tap(UpdatePolicy)
                 .Tap(WriteAuditLog)
                 .Bind(UpdateDisplayedMarkupFormula);
@@ -131,24 +131,24 @@ namespace HappyTravel.Edo.Api.Services.Markups
 
             Task WriteAuditLog(MarkupPolicy policy)
                 => _markupPolicyAuditService.Write(MarkupPolicyEventType.AgentMarkupUpdated,
-                    new AgentMarkupPolicyData(policy.Id, agentId, default),
+                    new AgentMarkupPolicyData(policy.Id, policy.AgentId.Value, policy.AgencyId.Value),
                     agent.ToUserInfo());
         }
 
 
-        public async Task<List<MarkupInfo>> Get(int agentId)
+        public async Task<List<MarkupInfo>> Get(int agentId, int agencyId)
         {
-            var policies = await GetAgentPolicies(agentId);
+            var policies = await GetAgentPolicies(agentId, agencyId);
             return policies
                 .Select(p=> new MarkupInfo(p.Id, p.GetSettings()))
                 .ToList();
         }
 
 
-        private Task<List<MarkupPolicy>> GetAgentPolicies(int agentId)
+        private Task<List<MarkupPolicy>> GetAgentPolicies(int agentId, int agencyId)
         {
             return _context.MarkupPolicies
-                .Where(p => p.ScopeType == MarkupPolicyScopeType.Agent && p.AgentId == agentId)
+                .Where(p => p.ScopeType == MarkupPolicyScopeType.Agent && p.AgentId == agentId && p.AgencyId == agencyId)
                 .OrderBy(p => p.Order)
                 .ToListAsync();
         }
@@ -163,7 +163,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
         }
         
 
-        private Task<Result> ValidateSettings(int agentId, MarkupPolicySettings settings, int? policyId = null)
+        private Task<Result> ValidateSettings(int agentId, int agencyId, MarkupPolicySettings settings, int? policyId = null)
         {
             return ValidateTemplate()
                 .Ensure(PolicyOrderIsUniqueForScope, "Policy with same order is already defined");
@@ -174,7 +174,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
 
             async Task<bool> PolicyOrderIsUniqueForScope()
             {
-                var isSameOrderPolicyExist = (await GetAgentPolicies(agentId))
+                var isSameOrderPolicyExist = (await GetAgentPolicies(agentId, agencyId))
                     .Any(p => p.Order == settings.Order && p.Id != policyId);
 
                 return !isSameOrderPolicyExist;
@@ -185,13 +185,15 @@ namespace HappyTravel.Edo.Api.Services.Markups
         private async Task<Result<MarkupPolicy>> GetAgentPolicy(AgentAgencyRelation relation, int policyId)
         {
             var policy = await _context.MarkupPolicies
-                .SingleOrDefaultAsync(p => p.Id == policyId && p.AgentId.HasValue && p.AgentId.Value == relation.AgentId);
+                .SingleOrDefaultAsync(p => p.Id == policyId && p.AgentId.HasValue && p.AgentId.Value == relation.AgentId 
+                    && p.AgencyId.HasValue && p.AgencyId == relation.AgencyId);
 
             return policy ?? Result.Failure<MarkupPolicy>("Could not find agent policy");
         }
 
-        
-        private Task<Result> UpdateDisplayedMarkupFormula(MarkupPolicy policy) => _displayedMarkupFormulaService.Update(policy.AgentId.Value);
+
+        private Task<Result> UpdateDisplayedMarkupFormula(MarkupPolicy policy)
+            => _displayedMarkupFormulaService.Update(policy.AgentId.Value, policy.AgencyId.Value);
 
 
         private readonly IMarkupPolicyTemplateService _templateService;

--- a/Api/Services/Markups/AgentMarkupPolicyManager.cs
+++ b/Api/Services/Markups/AgentMarkupPolicyManager.cs
@@ -185,8 +185,8 @@ namespace HappyTravel.Edo.Api.Services.Markups
         private async Task<Result<MarkupPolicy>> GetAgentPolicy(AgentAgencyRelation relation, int policyId)
         {
             var policy = await _context.MarkupPolicies
-                .SingleOrDefaultAsync(p => p.Id == policyId && p.AgentId.HasValue && p.AgentId.Value == relation.AgentId 
-                    && p.AgencyId.HasValue && p.AgencyId == relation.AgencyId);
+                .SingleOrDefaultAsync(p => p.Id == policyId && p.ScopeType == MarkupPolicyScopeType.Agent && p.AgentId.HasValue 
+                    && p.AgentId.Value == relation.AgentId && p.AgencyId.HasValue && p.AgencyId == relation.AgencyId);
 
             return policy ?? Result.Failure<MarkupPolicy>("Could not find agent policy");
         }

--- a/Api/Services/Markups/DisplayedMarkupFormulaService.cs
+++ b/Api/Services/Markups/DisplayedMarkupFormulaService.cs
@@ -18,26 +18,26 @@ namespace HappyTravel.Edo.Api.Services.Markups
         }
 
 
-        public async Task<Result> Update(int agentId)
+        public async Task<Result> Update(int agentId, int agencyId)
         {
-            var agent = await _context.Agents
-                .SingleOrDefaultAsync(a => a.Id == agentId);
+            var relation = await _context.AgentAgencyRelations
+                .SingleOrDefaultAsync(r => r.AgentId == agentId && r.AgencyId == agencyId);
 
-            if (agent is null)
-                return Result.Failure<Agent>($"Agent with id {agentId} not found");
+            if (relation is null)
+                return Result.Failure<Agent>($"Agent with id {agentId} not found in agency with id {agencyId}");
 
-            agent.DisplayedMarkupFormula = await GetAgentMarkupFormula(agent.Id);
-            _context.Agents.Update(agent);
+            relation.DisplayedMarkupFormula = await GetAgentMarkupFormula(relation.AgentId, relation.AgencyId);
+            _context.AgentAgencyRelations.Update(relation);
             await _context.SaveChangesAsync();
 
             return Result.Success();
         }
 
 
-        private async Task<string> GetAgentMarkupFormula(int agentId)
+        private async Task<string> GetAgentMarkupFormula(int agentId, int agencyId)
         {
             var policies = await _context.MarkupPolicies
-                .Where(p => p.AgentId == agentId && p.ScopeType == MarkupPolicyScopeType.Agent)
+                .Where(p => p.AgentId == agentId && p.AgencyId == agencyId && p.ScopeType == MarkupPolicyScopeType.Agent)
                 .OrderBy(p => p.Order)
                 .ToListAsync();
 

--- a/Api/Services/Markups/IAgentMarkupPolicyManager.cs
+++ b/Api/Services/Markups/IAgentMarkupPolicyManager.cs
@@ -14,6 +14,6 @@ namespace HappyTravel.Edo.Api.Services.Markups
 
         Task<Result> Modify(int agentId, int policyId, MarkupPolicySettings settings, AgentContext agent);
 
-        Task<List<MarkupInfo>> Get(int agentId);
+        Task<List<MarkupInfo>> Get(int agentId, int agencyId);
     }
 }

--- a/Api/Services/Markups/IDisplayedMarkupFormulaService.cs
+++ b/Api/Services/Markups/IDisplayedMarkupFormulaService.cs
@@ -5,6 +5,6 @@ namespace HappyTravel.Edo.Api.Services.Markups
 {
     public interface IDisplayedMarkupFormulaService
     {
-        public Task<Result> Update(int agentId);
+        public Task<Result> Update(int agentId, int agencyId);
     }
 }

--- a/Api/Services/Markups/MarkupPolicyService.cs
+++ b/Api/Services/Markups/MarkupPolicyService.cs
@@ -77,7 +77,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
                     p.ScopeType == MarkupPolicyScopeType.Global ||
                     p.ScopeType == MarkupPolicyScopeType.Counterparty && p.CounterpartyId == counterpartyId ||
                     p.ScopeType == MarkupPolicyScopeType.Agency && p.AgencyId == agencyId ||
-                    p.ScopeType == MarkupPolicyScopeType.Agent && p.AgentId == agentId ||
+                    p.ScopeType == MarkupPolicyScopeType.Agent && p.AgentId == agentId && p.AgencyId == agencyId ||
                     p.ScopeType == MarkupPolicyScopeType.EndClient && p.AgentId == agentId
                 )
                 .Where(p => p.ScopeType != MarkupPolicyScopeType.EndClient || userSettings.IsEndClientMarkupsEnabled)

--- a/HappyTravel.Edo.Data/Agents/Agent.cs
+++ b/HappyTravel.Edo.Data/Agents/Agent.cs
@@ -14,6 +14,5 @@ namespace HappyTravel.Edo.Data.Agents
         public string AppSettings { get; set; }
         public string UserSettings { get; set; }
         public DateTime Created { get; set; }
-        public string DisplayedMarkupFormula { get; set; }
     }
 }

--- a/HappyTravel.Edo.Data/Agents/AgentAgencyRelation.cs
+++ b/HappyTravel.Edo.Data/Agents/AgentAgencyRelation.cs
@@ -8,6 +8,7 @@ namespace HappyTravel.Edo.Data.Agents
         public InAgencyPermissions InAgencyPermissions { get; set; }
         public int AgencyId { get; set; }
         public AgentAgencyRelationTypes Type { get; set; }
+        public string DisplayedMarkupFormula { get; set; }
         public bool IsActive { get; set; }
 
 
@@ -19,6 +20,6 @@ namespace HappyTravel.Edo.Data.Agents
                 (other.AgentId, other.InAgencyPermissions, other.AgencyId, other.Type));
 
 
-        public override int GetHashCode() => (AgentId, InCounterpartyPermissions: InAgencyPermissions, AgencyId, Type).GetHashCode();
+        public override int GetHashCode() => (AgentId, InAgencyPermissions, AgencyId, Type).GetHashCode();
     }
 }

--- a/HappyTravel.Edo.Data/Migrations/20210219145917_MoveMarkupFormulaToRelation.Designer.cs
+++ b/HappyTravel.Edo.Data/Migrations/20210219145917_MoveMarkupFormulaToRelation.Designer.cs
@@ -8,6 +8,7 @@ using HappyTravel.Edo.Data.Agents;
 using HappyTravel.Edo.Data.Bookings;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -15,9 +16,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HappyTravel.Edo.Data.Migrations
 {
     [DbContext(typeof(EdoContext))]
-    partial class EdoContextModelSnapshot : ModelSnapshot
+    [Migration("20210219145917_MoveMarkupFormulaToRelation")]
+    partial class MoveMarkupFormulaToRelation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HappyTravel.Edo.Data/Migrations/20210219145917_MoveMarkupFormulaToRelation.cs
+++ b/HappyTravel.Edo.Data/Migrations/20210219145917_MoveMarkupFormulaToRelation.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace HappyTravel.Edo.Data.Migrations
+{
+    public partial class MoveMarkupFormulaToRelation : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DisplayedMarkupFormula",
+                table: "Agents");
+
+            migrationBuilder.AddColumn<string>(
+                name: "DisplayedMarkupFormula",
+                table: "AgentAgencyRelations",
+                type: "text",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DisplayedMarkupFormula",
+                table: "AgentAgencyRelations");
+
+            migrationBuilder.AddColumn<string>(
+                name: "DisplayedMarkupFormula",
+                table: "Agents",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/HappyTravel.Edo.Data/Migrations/20210219145917_MoveMarkupFormulaToRelation.cs
+++ b/HappyTravel.Edo.Data/Migrations/20210219145917_MoveMarkupFormulaToRelation.cs
@@ -6,28 +6,36 @@ namespace HappyTravel.Edo.Data.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropColumn(
-                name: "DisplayedMarkupFormula",
-                table: "Agents");
-
             migrationBuilder.AddColumn<string>(
                 name: "DisplayedMarkupFormula",
                 table: "AgentAgencyRelations",
                 type: "text",
                 nullable: true);
+
+            migrationBuilder.Sql(
+                "UPDATE \"AgentAgencyRelations\" r " +
+                "SET \"DisplayedMarkupFormula\" = (SELECT a.\"DisplayedMarkupFormula\" FROM \"Agents\" a WHERE a.\"Id\" = r.\"AgentId\")");
+
+            migrationBuilder.DropColumn(
+                name: "DisplayedMarkupFormula",
+                table: "Agents");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropColumn(
-                name: "DisplayedMarkupFormula",
-                table: "AgentAgencyRelations");
-
             migrationBuilder.AddColumn<string>(
                 name: "DisplayedMarkupFormula",
                 table: "Agents",
                 type: "text",
                 nullable: true);
+
+            migrationBuilder.Sql(
+                "UPDATE \"Agents\" a " +
+                "SET \"DisplayedMarkupFormula\" = (SELECT r.\"DisplayedMarkupFormula\" FROM \"AgentAgencyRelations\" r WHERE a.\"Id\" = r.\"AgentId\")");
+
+            migrationBuilder.DropColumn(
+                name: "DisplayedMarkupFormula",
+                table: "AgentAgencyRelations");
         }
     }
 }

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupServiceTests/MarkupsApplyingOrder.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupServiceTests/MarkupsApplyingOrder.cs
@@ -142,6 +142,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupServiceTests
             {
                 Id = 1,
                 AgentId = AgentContext.AgentId,
+                AgencyId = AgentContext.AgencyId,
                 Order = 21,
                 Target = MarkupPolicyTarget.AccommodationAvailability,
                 ScopeType = MarkupPolicyScopeType.Agent,
@@ -152,6 +153,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupServiceTests
             {
                 Id = 2,
                 AgentId = AgentContext.AgentId,
+                AgencyId = AgentContext.AgencyId,
                 Order = 1,
                 Target = MarkupPolicyTarget.AccommodationAvailability,
                 ScopeType = MarkupPolicyScopeType.Agent,


### PR DESCRIPTION
This is second part of a partial pull request.
Added `agencyId` into all read/write places of `MarkupPolicies` table when dealing with agents markups.
Also added audit logging to admin service and refactored scope validation a bit.