### PR TITLE
Fix. Not send the summary booking report to an inactive agent

### DIFF
--- a/Api/Services/Accommodations/Bookings/Mailing/BookingReportsService.cs
+++ b/Api/Services/Accommodations/Bookings/Mailing/BookingReportsService.cs
@@ -57,6 +57,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Mailing
                             on relation.AgentId equals agent.Id
                         where relation.AgencyId == agencyId
                             && relation.InAgencyPermissions.HasFlag(InAgencyPermissions.ReceiveBookingSummary)
+                            && relation.IsActive
                         select new EmailAndSetting
                         {
                             Email = agent.Email,


### PR DESCRIPTION
Fix. Not send the summary booking report to an inactive agent