### PR TITLE
Moved booking status change processing to a separate service

### DIFF
--- a/Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -577,6 +577,9 @@ namespace HappyTravel.Edo.Api.Infrastructure
             services.AddTransient<IBookingRateChecker, BookingRateChecker>();
             services.AddTransient<IBookingRequestStorage, BookingRequestStorage>();
             services.AddTransient<IBookingResponseProcessor, BookingResponseProcessor>();
+            
+            services.AddTransient<IBookingStatusChangesProcessor, BookingStatusChangesProcessor>();
+            
             services.AddTransient<IBookingMoneyReturnService, BookingMoneyReturnService>();
             services.AddTransient<IBookingsProcessingService, BookingsProcessingService>();
             services.AddTransient<IDeadlineService, DeadlineService>();

--- a/Api/Services/Accommodations/Bookings/BatchProcessing/BookingsProcessingService.cs
+++ b/Api/Services/Accommodations/Bookings/BatchProcessing/BookingsProcessingService.cs
@@ -204,7 +204,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.BatchProcessing
 
             Task<Result<string>> ProcessBooking(Booking booking, UserInfo _)
             {
-                return _bookingManagementService.Cancel(booking, serviceAccount.ToUserInfo(), true)
+                return _bookingManagementService.Cancel(booking, serviceAccount.ToUserInfo())
                     .Finally(CreateResult);
 
 

--- a/Api/Services/Accommodations/Bookings/BookingStatusChangesProcessor.cs
+++ b/Api/Services/Accommodations/Bookings/BookingStatusChangesProcessor.cs
@@ -1,0 +1,144 @@
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Infrastructure.Logging;
+using HappyTravel.Edo.Api.Models.Bookings;
+using HappyTravel.Edo.Api.Models.Users;
+using HappyTravel.Edo.Api.Services.Accommodations.Bookings.Mailing;
+using HappyTravel.Edo.Api.Services.Accommodations.Bookings.Management;
+using HappyTravel.Edo.Api.Services.Accommodations.Bookings.Payments;
+using HappyTravel.Edo.Api.Services.SupplierOrders;
+using HappyTravel.Edo.Data;
+using HappyTravel.Edo.Data.Bookings;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
+{
+    public class BookingStatusChangesProcessor : IBookingStatusChangesProcessor
+    {
+        public BookingStatusChangesProcessor(IBookingInfoService bookingInfoService,
+            IBookingRecordManager recordManager,
+            IBookingNotificationService notificationService,
+            ISupplierOrderService supplierOrderService,
+            IBookingDocumentsMailingService documentsMailingService,
+            IBookingMoneyReturnService moneyReturnService,
+            EdoContext context,
+            ILogger<BookingStatusChangesProcessor> logger)
+        {
+            _bookingInfoService = bookingInfoService;
+            _recordManager = recordManager;
+            _notificationService = notificationService;
+            _supplierOrderService = supplierOrderService;
+            _documentsMailingService = documentsMailingService;
+            _moneyReturnService = moneyReturnService;
+            _context = context;
+            _logger = logger;
+        }
+        
+        
+        public async Task ProcessConfirmation(Edo.Data.Bookings.Booking booking)
+        {
+            await GetBookingInfo(booking.ReferenceCode, booking.LanguageCode)
+                .Tap(SetConfirmationDate)
+                .Tap(NotifyBookingFinalization)
+                .Bind(SendInvoice)
+                .OnFailure(WriteFailureLog);
+            
+            
+            Task<Result<AccommodationBookingInfo>> GetBookingInfo(string referenceCode, string languageCode) 
+                => _bookingInfoService.GetAccommodationBookingInfo(referenceCode, languageCode);
+
+
+            Task SetConfirmationDate(AccommodationBookingInfo _) 
+                => _recordManager.SetConfirmationDate(booking);
+
+
+            Task NotifyBookingFinalization(AccommodationBookingInfo bookingInfo) 
+                => _notificationService.NotifyBookingFinalized(bookingInfo);
+
+
+            async Task<Result> SendInvoice(AccommodationBookingInfo bookingInfo)
+            {
+                // Booking was updated so we need to get it again
+                var (_, _, updatedBooking, _) = await _recordManager.Get(bookingInfo.BookingId);
+                return await _documentsMailingService.SendInvoice(updatedBooking, bookingInfo.AgentInformation.AgentEmail, true);
+            }
+
+
+            void WriteFailureLog(string error) 
+                => _logger.LogBookingConfirmationFailure($"Booking '{booking.ReferenceCode} confirmation failed: '{error}");
+        }
+        
+        
+        public Task<Result> ProcessCancellation(Edo.Data.Bookings.Booking booking, UserInfo user)
+        {
+            return SendNotifications()
+                .Tap(CancelSupplierOrder)
+                .Bind(() => ReturnMoney(booking, user));
+
+            
+            Task CancelSupplierOrder() 
+                => _supplierOrderService.Cancel(booking.ReferenceCode);
+
+
+            async Task<Result> SendNotifications()
+            {
+                var agent = await _context.Agents.SingleOrDefaultAsync(a => a.Id == booking.AgentId);
+                if (agent == default)
+                {
+                    _logger.LogWarning("Booking cancellation notification: could not find agent with id '{0}' for the booking '{1}'",
+                        booking.AgentId, booking.ReferenceCode);
+
+                    return Result.Success();
+                }
+
+                var (_, _, bookingInfo, _) = await _bookingInfoService.GetAccommodationBookingInfo(booking.ReferenceCode, booking.LanguageCode);
+                await _notificationService.NotifyBookingCancelled(bookingInfo);
+                
+                return Result.Success();
+            }
+        }
+
+
+        public Task ProcessRejection(Edo.Data.Bookings.Booking booking, UserInfo user)
+        {
+            return CancelSupplierOrder()
+                .Bind(() => ReturnMoney(booking, user));
+
+            
+            async Task<Result> CancelSupplierOrder()
+            {
+                await _supplierOrderService.Cancel(booking.ReferenceCode);
+                return Result.Success();
+            }
+        }
+
+
+        public Task<Result> ProcessDiscarding(Booking booking, UserInfo user)
+        {
+            return CancelSupplierOrder()
+                .Bind(() => ReturnMoney(booking, user));
+            
+            
+            async Task<Result> CancelSupplierOrder()
+            {
+                await _supplierOrderService.Cancel(booking.ReferenceCode);
+                return Result.Success();
+            }
+        }
+
+        
+        private Task<Result> ReturnMoney(Booking booking, UserInfo user) 
+            => _moneyReturnService.ReturnMoney(booking, user);
+        
+        
+        private readonly IBookingInfoService _bookingInfoService;
+        private readonly IBookingRecordManager _recordManager;
+        private readonly IBookingNotificationService _notificationService;
+        private readonly ISupplierOrderService _supplierOrderService;
+        private readonly IBookingDocumentsMailingService _documentsMailingService;
+        private readonly IBookingMoneyReturnService _moneyReturnService;
+        private readonly EdoContext _context;
+        private readonly ILogger<BookingStatusChangesProcessor> _logger;
+    }
+}

--- a/Api/Services/Accommodations/Bookings/IBookingStatusChangesProcessor.cs
+++ b/Api/Services/Accommodations/Bookings/IBookingStatusChangesProcessor.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Models.Users;
+
+namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
+{
+    public interface IBookingStatusChangesProcessor
+    {
+        Task ProcessConfirmation(Edo.Data.Bookings.Booking booking);
+
+        Task<Result> ProcessCancellation(Edo.Data.Bookings.Booking booking, UserInfo user);
+
+        Task ProcessRejection(Edo.Data.Bookings.Booking booking, UserInfo user);
+
+        Task<Result> ProcessDiscarding(Edo.Data.Bookings.Booking booking, UserInfo user);
+    }
+}

--- a/Api/Services/Accommodations/Bookings/Management/IBookingManagementService.cs
+++ b/Api/Services/Accommodations/Bookings/Management/IBookingManagementService.cs
@@ -10,7 +10,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Management
     /// </summary>
     public interface IBookingManagementService
     {
-        Task<Result> Cancel(Booking booking, UserInfo user, bool requireSupplierConfirmation = true);
+        Task<Result> Cancel(Booking booking, UserInfo user);
         
         Task<Result> RefreshStatus(Booking booking, UserInfo user);
 

--- a/Api/Services/Accommodations/Bookings/ResponseProcessing/BookingResponseProcessor.cs
+++ b/Api/Services/Accommodations/Bookings/ResponseProcessing/BookingResponseProcessor.cs
@@ -3,17 +3,11 @@ using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Infrastructure;
 using HappyTravel.Edo.Api.Infrastructure.Logging;
-using HappyTravel.Edo.Api.Models.Bookings;
 using HappyTravel.Edo.Api.Models.Users;
-using HappyTravel.Edo.Api.Services.Accommodations.Bookings.Mailing;
 using HappyTravel.Edo.Api.Services.Accommodations.Bookings.Management;
-using HappyTravel.Edo.Api.Services.Accommodations.Bookings.Payments;
-using HappyTravel.Edo.Api.Services.SupplierOrders;
 using HappyTravel.Edo.Common.Enums;
-using HappyTravel.Edo.Data;
 using HappyTravel.EdoContracts.Accommodations;
 using HappyTravel.EdoContracts.Accommodations.Enums;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.ResponseProcessing
@@ -23,24 +17,14 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.ResponseProcessin
         public BookingResponseProcessor(IBookingAuditLogService bookingAuditLogService,
             IBookingRecordManager bookingRecordManager,
             ILogger<BookingResponseProcessor> logger,
-            ISupplierOrderService supplierOrderService,
-            IBookingNotificationService bookingNotificationService,
             IDateTimeProvider dateTimeProvider, 
-            IBookingMoneyReturnService moneyReturnService,
-            IBookingInfoService bookingInfoService,
-            IBookingDocumentsMailingService documentsMailingService,
-            EdoContext context)
+            IBookingStatusChangesProcessor statusChangesProcessor)
         {
             _bookingAuditLogService = bookingAuditLogService;
             _bookingRecordManager = bookingRecordManager;
             _logger = logger;
-            _supplierOrderService = supplierOrderService;
-            _bookingNotificationService = bookingNotificationService;
             _dateTimeProvider = dateTimeProvider;
-            _moneyReturnService = moneyReturnService;
-            _bookingInfoService = bookingInfoService;
-            _documentsMailingService = documentsMailingService;
-            _context = context;
+            _statusChangesProcessor = statusChangesProcessor;
         }
         
         
@@ -77,87 +61,19 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.ResponseProcessin
             switch (bookingResponse.Status)
             {
                 case BookingStatusCodes.Confirmed:
-                    await ProcessConfirmation(booking, bookingResponse);
+                    await _statusChangesProcessor.ProcessConfirmation(booking);
                     break;
                 case BookingStatusCodes.Cancelled:
-                    await ProcessCancellation(booking, UserInfo.InternalServiceAccount);
+                    await _statusChangesProcessor.ProcessCancellation(booking, UserInfo.InternalServiceAccount);
                     break;
                 case BookingStatusCodes.Rejected:
-                    await ProcessRejection(booking, UserInfo.InternalServiceAccount);
+                    await _statusChangesProcessor.ProcessRejection(booking, UserInfo.InternalServiceAccount);
                     break;
             }
 
             _logger.LogBookingResponseProcessSuccess(
                 $"The booking response with the reference code '{bookingResponse.ReferenceCode}' has been successfully processed. " +
                 $"New status: {bookingResponse.Status}");
-        }
-        
-        private Task<Result> ProcessCancellation(Edo.Data.Bookings.Booking booking, UserInfo user)
-        {
-            return SendNotifications()
-                .Tap(CancelSupplierOrder)
-                .Bind(() => ReturnMoney(booking, user))
-                .Tap(SetBookingCancelled);
-
-            
-            Task CancelSupplierOrder() 
-                => _supplierOrderService.Cancel(booking.ReferenceCode);
-
-
-            async Task<Result> SendNotifications()
-            {
-                var agent = await _context.Agents.SingleOrDefaultAsync(a => a.Id == booking.AgentId);
-                if (agent == default)
-                {
-                    _logger.LogWarning("Booking cancellation notification: could not find agent with id '{0}' for the booking '{1}'",
-                        booking.AgentId, booking.ReferenceCode);
-
-                    return Result.Success();
-                }
-
-                var (_, _, bookingInfo, _) = await _bookingInfoService.GetAccommodationBookingInfo(booking.ReferenceCode, booking.LanguageCode);
-                await _bookingNotificationService.NotifyBookingCancelled(bookingInfo);
-                
-                return Result.Success();
-            }
-
-
-            Task SetBookingCancelled() 
-                => _bookingRecordManager.SetStatus(booking.ReferenceCode, BookingStatuses.Cancelled);
-        }
-        
-        
-        private async Task ProcessConfirmation(Edo.Data.Bookings.Booking booking, EdoContracts.Accommodations.Booking bookingResponse)
-        {
-            await GetBookingInfo(booking.ReferenceCode, booking.LanguageCode)
-                .Tap(SetConfirmationDate)
-                .Tap(NotifyBookingFinalization)
-                .Bind(SendInvoice)
-                .OnFailure(WriteFailureLog);
-            
-            
-            Task<Result<AccommodationBookingInfo>> GetBookingInfo(string referenceCode, string languageCode) 
-                => _bookingInfoService.GetAccommodationBookingInfo(referenceCode, languageCode);
-
-
-            Task SetConfirmationDate(AccommodationBookingInfo _) 
-                => _bookingRecordManager.SetConfirmationDate(booking);
-            
-            
-            Task NotifyBookingFinalization(AccommodationBookingInfo bookingInfo) 
-                => _bookingNotificationService.NotifyBookingFinalized(bookingInfo);
-
-
-            async Task<Result> SendInvoice(AccommodationBookingInfo bookingInfo)
-            {
-                // Booking was updated so we need to get it again
-                var (_, _, updatedBooking, _) = await _bookingRecordManager.Get(bookingInfo.BookingId);
-                return await _documentsMailingService.SendInvoice(updatedBooking, bookingInfo.AgentInformation.AgentEmail, true);
-            }
-
-
-            void WriteFailureLog(string error) 
-                => _logger.LogBookingConfirmationFailure($"Booking '{booking.ReferenceCode} confirmation failed: '{error}");
         }
         
         
@@ -175,42 +91,14 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.ResponseProcessin
                     $"The booking response with the reference code '{bookingResponse.ReferenceCode}' set as needed manual processing.");
             }
         }
-
-
-        private Task ProcessRejection(Edo.Data.Bookings.Booking booking, UserInfo user)
-        {
-            return CancelSupplierOrder()
-                .Bind(() => ReturnMoney(booking, user))
-                .Tap(SetBookingRejected);
-
-            
-            async Task<Result> CancelSupplierOrder()
-            {
-                await _supplierOrderService.Cancel(booking.ReferenceCode);
-                return Result.Success();
-            }
-
-
-            Task SetBookingRejected() 
-                => _bookingRecordManager.SetStatus(booking.ReferenceCode, BookingStatuses.Rejected);
-        }
-
-
-        Task<Result> ReturnMoney(Edo.Data.Bookings.Booking booking, UserInfo user) 
-            => _moneyReturnService.ReturnMoney(booking, user);
         
         
         private static readonly TimeSpan BookingCheckTimeout = TimeSpan.FromMinutes(30);
         
         private readonly IBookingAuditLogService _bookingAuditLogService;
         private readonly ILogger<BookingResponseProcessor> _logger;
-        private readonly ISupplierOrderService _supplierOrderService;
         private readonly IBookingRecordManager _bookingRecordManager;
-        private readonly IBookingNotificationService _bookingNotificationService;
         private readonly IDateTimeProvider _dateTimeProvider;
-        private readonly IBookingMoneyReturnService _moneyReturnService;
-        private readonly IBookingInfoService _bookingInfoService;
-        private readonly IBookingDocumentsMailingService _documentsMailingService;
-        private readonly EdoContext _context;
+        private readonly IBookingStatusChangesProcessor _statusChangesProcessor;
     }
 }

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Accommodations/Bookings/BookingsProcessingServiceTests/Cancellation/ExecutingCancellation.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Accommodations/Bookings/BookingsProcessingServiceTests/Cancellation/ExecutingCancellation.cs
@@ -51,7 +51,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Bookings.Booki
 
             bookingServiceMock
                 .Verify(
-                    b => b.Cancel(It.IsAny<Booking>(), It.IsAny<UserInfo>(), true),
+                    b => b.Cancel(It.IsAny<Booking>(), It.IsAny<UserInfo>()),
                     Times.Exactly(2)
                 );
         }

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Accommodations/Bookings/BookingsProcessingServiceTests/Charging/ExecutingCharging.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Accommodations/Bookings/BookingsProcessingServiceTests/Charging/ExecutingCharging.cs
@@ -77,7 +77,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Bookings.Booki
 
             bookingServiceMock
                 .Verify(
-                    b => b.Cancel(It.IsAny<Booking>(), It.IsAny<UserInfo>(), true),
+                    b => b.Cancel(It.IsAny<Booking>(), It.IsAny<UserInfo>()),
                     Times.Exactly(2)
                 );
         }
@@ -95,7 +95,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Bookings.Booki
 
             bookingServiceMock
                 .Verify(
-                    b => b.Cancel(It.IsAny<Booking>(), It.IsAny<UserInfo>(), true),
+                    b => b.Cancel(It.IsAny<Booking>(), It.IsAny<UserInfo>()),
                     Times.Exactly(0)
                 );
         }


### PR DESCRIPTION
This is a step to update booking statuses in two separate flows:
1. From supplier booking status
2. From administrator endpoints