### PR TITLE
Add hash and equals methods to invitation data structs

### DIFF
--- a/Api/Models/Agencies/AgencyInfo.cs
+++ b/Api/Models/Agencies/AgencyInfo.cs
@@ -29,5 +29,17 @@ namespace HappyTravel.Edo.Api.Models.Agencies
         ///     Id of the counterparty.
         /// </summary>
         public int? CounterpartyId { get; }
+
+
+        public override int GetHashCode()
+            => (Name, Id, CounterpartyId).GetHashCode();
+
+
+        public bool Equals(AgencyInfo other)
+            => (Name, Id, CounterpartyId) == (other.Name, other.Id, other.CounterpartyId);
+
+
+        public override bool Equals(object obj)
+            => obj is AgencyInfo other && Equals(other);
     }
 }

--- a/Api/Models/Invitations/UserInvitationData.cs
+++ b/Api/Models/Invitations/UserInvitationData.cs
@@ -27,5 +27,17 @@ namespace HappyTravel.Edo.Api.Models.Invitations
         /// Prefilled child agency registration info. Used only for child agency invitations.
         /// </summary>
         public AgencyInfo ChildAgencyRegistrationInfo { get; }
+
+
+        public override int GetHashCode()
+            => (UserRegistrationInfo, ChildAgencyRegistrationInfo).GetHashCode();
+
+
+        public bool Equals(UserInvitationData other)
+            => UserRegistrationInfo.Equals(other.UserRegistrationInfo) && ChildAgencyRegistrationInfo.Equals(other.ChildAgencyRegistrationInfo);
+
+
+        public override bool Equals(object obj)
+            => obj is UserInvitationData other && Equals(other);
     }
 }

--- a/Api/Models/Users/UserDescriptionInfo.cs
+++ b/Api/Models/Users/UserDescriptionInfo.cs
@@ -44,5 +44,17 @@ namespace HappyTravel.Edo.Api.Models.Users
         ///     Email
         /// </summary>
         public string Email { get; }
+
+
+        public override int GetHashCode()
+            => (Title, FirstName, LastName, Position, Email).GetHashCode();
+
+
+        public bool Equals(UserDescriptionInfo other)
+            => (Title, FirstName, LastName, Position, Email) == (other.Title, other.FirstName, other.LastName, other.Position, other.Email);
+
+
+        public override bool Equals(object obj)
+            => obj is UserDescriptionInfo other && Equals(other);
     }
 }


### PR DESCRIPTION
https://github.com/happy-travel/agent-app-project/issues/42

equals(default) was failing due to lack of overriden equals and hash methods