### PR TITLE
Removed default deadline buffer

### DIFF
--- a/Api/Services/Accommodations/Bookings/BatchProcessing/BookingsProcessingService.cs
+++ b/Api/Services/Accommodations/Bookings/BatchProcessing/BookingsProcessingService.cs
@@ -46,12 +46,11 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.BatchProcessing
         public Task<List<int>> GetForCapture(DateTime date)
         {
             date = date.Date;
-            var daysBeforeDeadline = BookingConstants.DaysBeforeDeadlineWhenToPay;
 
             return _context.Bookings
                 .Where(IsBookingValidForCapturePredicate)
-                .Where(b => b.CheckInDate <= date.AddDays(daysBeforeDeadline) 
-                    || (b.DeadlineDate.HasValue && b.DeadlineDate.Value.Date <= date.AddDays(daysBeforeDeadline)))
+                .Where(b => b.CheckInDate <= date 
+                    || (b.DeadlineDate.HasValue && b.DeadlineDate.Value.Date <= date))
                 .Select(b => b.Id)
                 .ToListAsync();
         }
@@ -72,12 +71,11 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.BatchProcessing
         public Task<List<int>> GetForCharge(DateTime date)
         {
             date = date.Date;
-            var daysBeforeDeadline = BookingConstants.DaysBeforeDeadlineWhenToPay;
 
             return _context.Bookings
                 .Where(IsBookingValidForChargePredicate)
-                .Where(b => b.CheckInDate <= date.AddDays(daysBeforeDeadline) 
-                    || (b.DeadlineDate.HasValue && b.DeadlineDate.Value.Date <= date.AddDays(daysBeforeDeadline)))
+                .Where(b => b.CheckInDate <= date
+                    || (b.DeadlineDate.HasValue && b.DeadlineDate.Value.Date <= date))
                 .Select(b => b.Id)
                 .ToListAsync();
         }
@@ -334,7 +332,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.BatchProcessing
             BookingStatuses.Confirmed
         };
 
-        private static readonly HashSet<BookingPaymentStatuses> PaymentStatusesForCancellation = new HashSet<BookingPaymentStatuses>
+        private static readonly HashSet<BookingPaymentStatuses> PaymentStatusesForCancellation = new()
         {
             BookingPaymentStatuses.NotPaid, BookingPaymentStatuses.Refunded, BookingPaymentStatuses.Voided
         };

--- a/Api/Services/Accommodations/Bookings/BookingConstants.cs
+++ b/Api/Services/Accommodations/Bookings/BookingConstants.cs
@@ -1,7 +1,0 @@
-namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
-{
-    public static class BookingConstants
-    {
-        public const int DaysBeforeDeadlineWhenToPay = 1;
-    }
-}

--- a/Api/Services/Accommodations/Bookings/BookingExtensions.cs
+++ b/Api/Services/Accommodations/Bookings/BookingExtensions.cs
@@ -6,8 +6,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings
     public static class BookingExtensions
     {
         public static DateTime GetPayDueDate(this Data.Bookings.Booking booking)
-            => (booking.DeadlineDate == null || booking.DeadlineDate == DateTime.MinValue ? booking.CheckInDate : booking.DeadlineDate.Value)
-                .AddDays(-BookingConstants.DaysBeforeDeadlineWhenToPay);
+            => (booking.DeadlineDate == null || booking.DeadlineDate == DateTime.MinValue ? booking.CheckInDate : booking.DeadlineDate.Value);
 
 
         public static MoneyAmount GetTotalPrice(this Data.Bookings.Booking booking) 

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Accommodations/Bookings/BookingsProcessingServiceTests/Capturing/GettingForCapturing.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Accommodations/Bookings/BookingsProcessingServiceTests/Capturing/GettingForCapturing.cs
@@ -36,7 +36,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Bookings.Booki
 
             Assert.Contains(1, bookingsToCapture);
             Assert.Contains(2, bookingsToCapture);
-            Assert.Contains(3, bookingsToCapture);
+            Assert.DoesNotContain(3, bookingsToCapture);
             Assert.DoesNotContain(4, bookingsToCapture);
             Assert.DoesNotContain(5, bookingsToCapture);
 
@@ -68,7 +68,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Bookings.Booki
             var bookingsToCapture = await service.GetForCapture(date);
 
             Assert.Contains(1, bookingsToCapture);
-            Assert.Contains(2, bookingsToCapture);
+            Assert.DoesNotContain(2, bookingsToCapture);
             Assert.DoesNotContain(3, bookingsToCapture);
             Assert.DoesNotContain(4, bookingsToCapture);
 

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Accommodations/Bookings/BookingsProcessingServiceTests/Charging/GettingForCharging.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Accommodations/Bookings/BookingsProcessingServiceTests/Charging/GettingForCharging.cs
@@ -36,7 +36,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Bookings.Booki
 
             Assert.Contains(1, bookingsToCapture);
             Assert.Contains(2, bookingsToCapture);
-            Assert.Contains(3, bookingsToCapture);
+            Assert.DoesNotContain(3, bookingsToCapture);
             Assert.DoesNotContain(4, bookingsToCapture);
             Assert.DoesNotContain(5, bookingsToCapture);
 
@@ -68,7 +68,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Bookings.Booki
             var bookingsToCapture = await service.GetForCharge(date);
 
             Assert.Contains(1, bookingsToCapture);
-            Assert.Contains(2, bookingsToCapture);
+            Assert.DoesNotContain(2, bookingsToCapture);
             Assert.DoesNotContain(3, bookingsToCapture);
             Assert.DoesNotContain(4, bookingsToCapture);
 


### PR DESCRIPTION
We apply buffer on the availability search steps so there is no need to add additional one