### PR TITLE
Added discounts applicable to markups

### DIFF
--- a/Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -566,6 +566,8 @@ namespace HappyTravel.Edo.Api.Infrastructure
 
             services.AddTransient<IMarkupPolicyService, MarkupPolicyService>();
             services.AddTransient<IMarkupService, MarkupService>();
+            services.AddTransient<IDiscountFunctionService, DiscountFunctionService>();
+            
             services.AddTransient<IDisplayedMarkupFormulaService, DisplayedMarkupFormulaService>();
             services.AddTransient<IMarkupBonusMaterializationService, MarkupBonusMaterializationService>();
             services.AddTransient<IMarkupBonusDisplayService, MarkupBonusDisplayService>();

--- a/Api/Services/Markups/DiscountFunctionService.cs
+++ b/Api/Services/Markups/DiscountFunctionService.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FloxDc.CacheFlow;
+using FloxDc.CacheFlow.Extensions;
+using HappyTravel.Edo.Api.Models.Agents;
+using HappyTravel.Edo.Api.Services.PriceProcessing;
+using HappyTravel.Edo.Common.Enums.Markup;
+using HappyTravel.Edo.Data;
+using HappyTravel.Edo.Data.Markup;
+using HappyTravel.Money.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace HappyTravel.Edo.Api.Services.Markups
+{
+    public class DiscountFunctionService : IDiscountFunctionService
+    {
+        public DiscountFunctionService(EdoContext context, IDoubleFlow flow)
+        {
+            _context = context;
+            _flow = flow;
+        }
+        
+        
+        public async ValueTask<PriceProcessFunction> Get(MarkupPolicy policy, AgentContext agent)
+        {
+            // Discounts are only supported for global markups for now
+            if (policy.ScopeType != MarkupPolicyScopeType.Global)
+                return (price => new ValueTask<MoneyAmount>(price));
+
+            var discountsKey = GetKey(policy, agent);
+            var applicableDiscounts = await _flow.GetOrSetAsync(discountsKey, 
+                GetAgentDiscounts,
+                DiscountCacheLifeTime);
+
+            return moneyAmount =>
+            {
+                var currentAmount = moneyAmount;
+                foreach (var discount in applicableDiscounts)
+                {
+                    currentAmount = new MoneyAmount
+                    {
+                        Amount = currentAmount.Amount * (100 - discount.DiscountPercent) / 100,
+                        Currency = currentAmount.Currency
+                    };
+                }
+
+                return new ValueTask<MoneyAmount>(currentAmount);
+            };
+            
+            
+            string GetKey(MarkupPolicy markupPolicy, AgentContext agentContext) 
+                => _flow.BuildKey(nameof(DiscountFunctionService), nameof(GetAgentDiscounts), agentContext.AgencyId.ToString(), agentContext.AgentId.ToString(), markupPolicy.Id.ToString());
+
+            
+            Task<List<Discount>> GetAgentDiscounts()
+                => _context.Discounts
+                    .Where(d => d.TargetPolicyId == policy.Id)
+                    .Where(d => d.AgencyId == agent.AgencyId)
+                    .Where(d => d.IsEnabled)
+                    .ToListAsync();
+        }
+
+
+        private static readonly TimeSpan DiscountCacheLifeTime = TimeSpan.FromMinutes(2);
+        
+        private readonly EdoContext _context;
+        private readonly IDoubleFlow _flow;
+    }
+}

--- a/Api/Services/Markups/IDiscountFunctionService.cs
+++ b/Api/Services/Markups/IDiscountFunctionService.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using HappyTravel.Edo.Api.Models.Agents;
+using HappyTravel.Edo.Api.Services.PriceProcessing;
+using HappyTravel.Edo.Data.Markup;
+
+namespace HappyTravel.Edo.Api.Services.Markups
+{
+    public interface IDiscountFunctionService
+    {
+        ValueTask<PriceProcessFunction> Get(MarkupPolicy policy, AgentContext agent);
+    }
+}

--- a/Api/Services/Markups/MarkupService.cs
+++ b/Api/Services/Markups/MarkupService.cs
@@ -19,11 +19,13 @@ namespace HappyTravel.Edo.Api.Services.Markups
     public class MarkupService : IMarkupService
     {
         public MarkupService(IMarkupPolicyService markupPolicyService,
+            IDiscountFunctionService discountFunctionService,
             IMarkupPolicyTemplateService templateService,
             ICurrencyRateService currencyRateService,
             IMemoryFlow flow)
         {
             _markupPolicyService = markupPolicyService;
+            _discountFunctionService = discountFunctionService;
             _templateService = templateService;
             _currencyRateService = currencyRateService;
             _flow = flow;
@@ -40,8 +42,11 @@ namespace HappyTravel.Edo.Api.Services.Markups
             {
                 var detailsBefore = currentData;
                 
-                var processFunction = GetPriceProcessFunction(policy);
-                currentData = await priceProcessFunc(currentData, processFunction);
+                var markupFunction = GetPriceProcessFunction(policy);
+                currentData = await priceProcessFunc(currentData, markupFunction);
+
+                var discountFunction = await _discountFunctionService.Get(policy, agent);
+                currentData = await priceProcessFunc(currentData, discountFunction);;
 
                 logAction?.Invoke(new MarkupApplicationResult<TDetails>(detailsBefore, policy, currentData));
             }
@@ -94,6 +99,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
         private static readonly TimeSpan MarkupPolicyFunctionCachingTime = TimeSpan.FromDays(1);
         
         private readonly IMarkupPolicyService _markupPolicyService;
+        private readonly IDiscountFunctionService _discountFunctionService;
         private readonly IMemoryFlow _flow;
     }
 }

--- a/HappyTravel.Edo.Data/EdoContext.cs
+++ b/HappyTravel.Edo.Data/EdoContext.cs
@@ -267,6 +267,7 @@ namespace HappyTravel.Edo.Data
             BuildBookingStatusHistory(builder);
             BuildNotifications(builder);
             BuildNotificationOptions(builder);
+            BuildDiscounts(builder);
         }
 
 

--- a/HappyTravel.Edo.Data/EdoContext.cs
+++ b/HappyTravel.Edo.Data/EdoContext.cs
@@ -96,6 +96,8 @@ namespace HappyTravel.Edo.Data
         public virtual DbSet<BookingStatusHistoryEntry> BookingStatusHistory { get; set; }
         public DbSet<Notification> Notifications { get; set; }
         public DbSet<NotificationOptions> NotificationOptions { get; set; }
+        
+        public DbSet<Discount> Discounts { get; set; }
 
 
         [DbFunction("jsonb_to_string")]
@@ -916,6 +918,17 @@ namespace HappyTravel.Edo.Data
             builder.Entity<NotificationOptions>(b =>
             {
                 b.HasIndex(o => new {o.AgencyId, o.AgentId, o.Type}).IsUnique();
+            });
+        }
+        
+        
+        private static void BuildDiscounts(ModelBuilder builder)
+        {
+            builder.Entity<Discount>(b =>
+            {
+                b.HasIndex(d => d.AgencyId);
+                b.HasIndex(d => d.TargetPolicyId);
+                b.HasIndex(d => d.IsEnabled);
             });
         }
 

--- a/HappyTravel.Edo.Data/Markup/Discount.cs
+++ b/HappyTravel.Edo.Data/Markup/Discount.cs
@@ -1,0 +1,11 @@
+namespace HappyTravel.Edo.Data.Markup
+{
+    public class Discount
+    {
+        public int Id { get; set; }
+        public int AgencyId { get; set; }
+        public int TargetPolicyId { get; set; }
+        public decimal DiscountPercent { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+}

--- a/HappyTravel.Edo.Data/Migrations/20210418190606_AddDiscountsWithMarkups.Designer.cs
+++ b/HappyTravel.Edo.Data/Migrations/20210418190606_AddDiscountsWithMarkups.Designer.cs
@@ -10,6 +10,7 @@ using HappyTravel.Edo.Notifications.Enums;
 using HappyTravel.Edo.Notifications.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -17,9 +18,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HappyTravel.Edo.Data.Migrations
 {
     [DbContext(typeof(EdoContext))]
-    partial class EdoContextModelSnapshot : ModelSnapshot
+    [Migration("20210418190606_AddDiscountsWithMarkups")]
+    partial class AddDiscountsWithMarkups
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HappyTravel.Edo.Data/Migrations/20210418190606_AddDiscountsWithMarkups.cs
+++ b/HappyTravel.Edo.Data/Migrations/20210418190606_AddDiscountsWithMarkups.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace HappyTravel.Edo.Data.Migrations
+{
+    public partial class AddDiscountsWithMarkups : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Discounts",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    AgencyId = table.Column<int>(type: "integer", nullable: false),
+                    TargetPolicyId = table.Column<int>(type: "integer", nullable: false),
+                    DiscountPercent = table.Column<decimal>(type: "numeric", nullable: false),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Discounts", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Discounts");
+        }
+    }
+}

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupServiceTests/MarkupDisable.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupServiceTests/MarkupDisable.cs
@@ -87,7 +87,11 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupServiceTests
                 agentSettingsMock.Object,
                 accommodationBookingSettingsService);
             
-            return new MarkupService(functionService, new MarkupPolicyTemplateService(),
+            var discountServiceMock = new  Mock<IDiscountFunctionService>();
+            discountServiceMock.Setup(service => service.Get(It.IsAny<MarkupPolicy>(), It.IsAny<AgentContext>()))
+                .ReturnsAsync((price => new ValueTask<MoneyAmount>(price)));
+            
+            return new MarkupService(functionService, discountServiceMock.Object, new MarkupPolicyTemplateService(),
                 currencyRateServiceMock.Object, new FakeMemoryFlow());
         }
         

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupServiceTests/MarkupsApplyingOrder.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupServiceTests/MarkupsApplyingOrder.cs
@@ -60,8 +60,12 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupServiceTests
                 new FakeDoubleFlow(), 
                 agentSettingsMock.Object,
                 accommodationBookingSettingsServiceMock.Object);
+
+            var discountServiceMock = new  Mock<IDiscountFunctionService>();
+            discountServiceMock.Setup(service => service.Get(It.IsAny<MarkupPolicy>(), It.IsAny<AgentContext>()))
+                .ReturnsAsync((price => new ValueTask<MoneyAmount>(price)));
             
-            _markupService = new MarkupService(_markupPolicyService, new MarkupPolicyTemplateService(), currencyRateServiceMock.Object, new FakeMemoryFlow());
+            _markupService = new MarkupService(_markupPolicyService, discountServiceMock.Object, new MarkupPolicyTemplateService(), currencyRateServiceMock.Object, new FakeMemoryFlow());
         }
     
     


### PR DESCRIPTION
In this variant Discount is a thing that can be applied to a certain markup and markup id is needed to create a discount.
This is simple enough to implement and understand and automatically supports right markup bonuses calculation:
Every discount is applied to a given markup and all the bonuses will be calculated with the resulting value (discounts are integrated to markup bonuses).

From the other hand, setting markup not only by agency but by a markup too maybe confusing and not fully understandable.
"Why I cannot just select an agency and give it discount? Why I need to select a policy to apply markup to?"