### PR TITLE
Feature/aa 219 add notifications via notification center for account

### DIFF
--- a/Api/AdministratorServices/CounterpartyBillingNotificationService.cs
+++ b/Api/AdministratorServices/CounterpartyBillingNotificationService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
-using HappyTravel.Edo.Api.Infrastructure;
 using HappyTravel.Edo.Api.Infrastructure.Logging;
 using HappyTravel.Edo.Api.Infrastructure.Options;
 using HappyTravel.Edo.Api.Models.Mailing;

--- a/Api/Services/Accommodations/Bookings/Mailing/BookingNotificationService.cs
+++ b/Api/Services/Accommodations/Bookings/Mailing/BookingNotificationService.cs
@@ -94,8 +94,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Mailing
         public async Task<Result> NotifyCreditCardPaymentConfirmed(string referenceCode)
         {
             return await GetData()
-                .Tap(SendNotifyToAdmin)
-                .Tap(SendNotifyToAgent);
+                .Tap(SendNotificationToAdmin)
+                .Tap(SendNotificationToAgent);
 
 
             async Task<Result<CreditCardPaymentConfirmationNotification>> GetData()
@@ -128,11 +128,11 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Mailing
             }
 
 
-            Task SendNotifyToAdmin(CreditCardPaymentConfirmationNotification data)
+            Task SendNotificationToAdmin(CreditCardPaymentConfirmationNotification data)
                 => _mailSender.Send(_options.AdminCreditCardPaymentConfirmationTemplateId, _options.CcNotificationAddresses, data);
 
 
-            async Task SendNotifyToAgent(CreditCardPaymentConfirmationNotification data)
+            async Task SendNotificationToAgent(CreditCardPaymentConfirmationNotification data)
             {
                 var booking = await _context.Bookings.SingleOrDefaultAsync(b => b.ReferenceCode == data.ReferenceCode);
 

--- a/HappyTravel.Edo.Notifications/Enums/NotificationTypes.cs
+++ b/HappyTravel.Edo.Notifications/Enums/NotificationTypes.cs
@@ -3,6 +3,7 @@ namespace HappyTravel.Edo.Notifications.Enums
     public enum NotificationTypes
     {
         None = 0,
+        // Booking
         BookingVoucher = 1,
         BookingInvoice = 2,
         DeadlineApproaching = 3,
@@ -10,6 +11,9 @@ namespace HappyTravel.Edo.Notifications.Enums
         BookingDuePaymentDate = 5,
         BookingCancelled = 6,
         BookingFinalized = 7,
-        BookingStatusChanged = 8
+        BookingStatusChanged = 8,
+        // Accounts
+        CreditCardPaymentReceived = 9,
+        AccountBalanceReplenished = 10
     }
 }

--- a/HappyTravel.Edo.Notifications/Infrastructure/NotificationOptionsHelper.cs
+++ b/HappyTravel.Edo.Notifications/Infrastructure/NotificationOptionsHelper.cs
@@ -15,14 +15,16 @@ namespace HappyTravel.Edo.Notifications.Infrastructure
 
         private static readonly Dictionary<NotificationTypes, SlimNotificationOptions> _defaultOptions = new()
         {
-            { NotificationTypes.BookingVoucher, new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = true } },
-            { NotificationTypes.BookingInvoice, new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = true } },
-            { NotificationTypes.DeadlineApproaching, new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false } },
-            { NotificationTypes.SuccessfulPaymentReceipt, new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = true } },
-            { NotificationTypes.BookingDuePaymentDate, new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false } },
-            { NotificationTypes.BookingCancelled, new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false } },
-            { NotificationTypes.BookingFinalized, new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false } },
-            { NotificationTypes.BookingStatusChanged, new() { EnabledProtocols = ProtocolTypes.WebSocket, IsMandatory = false } },
+            [NotificationTypes.BookingVoucher] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = true },
+            [NotificationTypes.BookingInvoice] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = true },
+            [NotificationTypes.DeadlineApproaching] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },
+            [NotificationTypes.SuccessfulPaymentReceipt] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = true },
+            [NotificationTypes.BookingDuePaymentDate] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },
+            [NotificationTypes.BookingCancelled] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },
+            [NotificationTypes.BookingFinalized] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },
+            [NotificationTypes.BookingStatusChanged] = new() { EnabledProtocols = ProtocolTypes.WebSocket, IsMandatory = false },
+            [NotificationTypes.CreditCardPaymentReceived] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },
+            [NotificationTypes.AccountBalanceReplenished] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false }
         };
     }
 }


### PR DESCRIPTION
Added notifications via SignalR for events: EDO: Credit card payment received (Agent); EDO: Account balance has been replenished. Email for these events is sent via NotificationCenter.