### PR TITLE
AA-302 Show only your notification settings for admins and agents

### DIFF
--- a/Api/NotificationCenter/Services/NotificationOptionsService.cs
+++ b/Api/NotificationCenter/Services/NotificationOptionsService.cs
@@ -29,7 +29,7 @@ namespace HappyTravel.Edo.Api.NotificationCenter.Services
             var options = await GetOptions(userId, userType, agencyId, notificationType);
 
             return options is null 
-                ? NotificationOptionsHelper.TryGetDefaultOptions(notificationType) 
+                ? NotificationOptionsHelper.TryGetDefaultOptions(notificationType, userType) 
                 : new SlimNotificationOptions {EnabledProtocols = options.EnabledProtocols, IsMandatory = options.IsMandatory};
         }
 
@@ -40,7 +40,7 @@ namespace HappyTravel.Edo.Api.NotificationCenter.Services
                 .Where(o => o.AgencyId == agent.AgencyId && o.UserId == agent.AgentId && o.UserType == ApiCallerTypes.Agent)
                 .ToListAsync();
 
-            return GetMaterializedOptions(agentOptions);
+            return GetMaterializedOptions(agentOptions, ReceiverTypes.AgentApp);
         }
 
 
@@ -50,7 +50,7 @@ namespace HappyTravel.Edo.Api.NotificationCenter.Services
                 .Where(o => o.AgencyId == null && o.UserId == admin.AdminId && o.UserType == ApiCallerTypes.Admin)
                 .ToListAsync();
 
-            return GetMaterializedOptions(adminOptions);
+            return GetMaterializedOptions(adminOptions, ReceiverTypes.AdminPanel);
         }
 
 
@@ -85,7 +85,7 @@ namespace HappyTravel.Edo.Api.NotificationCenter.Services
 
                 Result<SlimNotificationOptions> Validate(KeyValuePair<NotificationTypes, NotificationSettings> option)
                 {
-                    var defaultOptions = NotificationOptionsHelper.TryGetDefaultOptions(option.Key);
+                    var defaultOptions = NotificationOptionsHelper.TryGetDefaultOptions(option.Key, userType);
                     if (defaultOptions.IsFailure)
                         return Result.Failure<SlimNotificationOptions>(defaultOptions.Error);
 
@@ -150,9 +150,9 @@ namespace HappyTravel.Edo.Api.NotificationCenter.Services
                 .SingleOrDefaultAsync(o => o.UserId == userId && o.UserType == userType && o.AgencyId == agencyId && o.Type == notificationType);
 
 
-        private static Dictionary<NotificationTypes, NotificationSettings> GetMaterializedOptions(List<NotificationOptions> userOptions)
+        private static Dictionary<NotificationTypes, NotificationSettings> GetMaterializedOptions(List<NotificationOptions> userOptions, ReceiverTypes receiver)
         {
-            var defaultOptions = NotificationOptionsHelper.GetDefaultOptions();
+            var defaultOptions = NotificationOptionsHelper.GetDefaultOptions(receiver);
             var materializedSettings = new Dictionary<NotificationTypes, NotificationSettings>();
 
             foreach (var option in defaultOptions)

--- a/HappyTravel.Edo.Notifications/Enums/ReceiverTypes.cs
+++ b/HappyTravel.Edo.Notifications/Enums/ReceiverTypes.cs
@@ -1,5 +1,8 @@
-﻿namespace HappyTravel.Edo.Notifications.Enums
+﻿using System;
+
+namespace HappyTravel.Edo.Notifications.Enums
 {
+    [Flags]
     public enum ReceiverTypes
     {
         None = 0,

--- a/HappyTravel.Edo.Notifications/HappyTravel.Edo.Notifications.csproj
+++ b/HappyTravel.Edo.Notifications/HappyTravel.Edo.Notifications.csproj
@@ -9,4 +9,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\HappyTravel.Edo.Common\HappyTravel.Edo.Common.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/HappyTravel.Edo.Notifications/Infrastructure/NotificationOptionsHelper.cs
+++ b/HappyTravel.Edo.Notifications/Infrastructure/NotificationOptionsHelper.cs
@@ -14,11 +14,11 @@ namespace HappyTravel.Edo.Notifications.Infrastructure
             var receiver = GetReceiver(userType);
             var options = _defaultOptions.TryGetValue(type, out var value)
                 ? value
-                : Result.Failure<SlimNotificationOptions>($"Cannot find options for type '{type}'");
+                : Result.Failure<SlimNotificationOptions>($"Cannot find options for the type '{type}'");
 
             return options.Value.EnabledReceivers.HasFlag(receiver)
                 ? options
-                : Result.Failure<SlimNotificationOptions>($"Cannot find options for type '{type}' and receiver '{receiver}'");
+                : Result.Failure<SlimNotificationOptions>($"Cannot find options for the type '{type}' and the receiver '{receiver}'");
 
 
             static ReceiverTypes GetReceiver(ApiCallerTypes userType)

--- a/HappyTravel.Edo.Notifications/Infrastructure/NotificationOptionsHelper.cs
+++ b/HappyTravel.Edo.Notifications/Infrastructure/NotificationOptionsHelper.cs
@@ -14,11 +14,11 @@ namespace HappyTravel.Edo.Notifications.Infrastructure
             var receiver = GetReceiver(userType);
             var options = _defaultOptions.TryGetValue(type, out var value)
                 ? value
-                : Result.Failure<SlimNotificationOptions>($"Cannot find options for the type '{type}'");
+                : Result.Failure<SlimNotificationOptions>($"Cannot find notification options for the type '{type}'");
 
             return options.Value.EnabledReceivers.HasFlag(receiver)
                 ? options
-                : Result.Failure<SlimNotificationOptions>($"Cannot find options for the type '{type}' and the receiver '{receiver}'");
+                : Result.Failure<SlimNotificationOptions>($"Cannot find notification options for the type '{type}' and the receiver '{receiver}'");
 
 
             static ReceiverTypes GetReceiver(ApiCallerTypes userType)

--- a/HappyTravel.Edo.Notifications/Infrastructure/NotificationOptionsHelper.cs
+++ b/HappyTravel.Edo.Notifications/Infrastructure/NotificationOptionsHelper.cs
@@ -1,55 +1,98 @@
 ﻿using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Common.Enums;
 using HappyTravel.Edo.Notifications.Enums;
 using HappyTravel.Edo.Notifications.Models;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace HappyTravel.Edo.Notifications.Infrastructure
 {
     public static class NotificationOptionsHelper
     {
-        public static Result<SlimNotificationOptions> TryGetDefaultOptions(NotificationTypes type) 
-            => _defaultOptions.TryGetValue(type, out var value)
+        public static Result<SlimNotificationOptions> TryGetDefaultOptions(NotificationTypes type, ApiCallerTypes userType)
+        {
+            var receiver = GetReceiver(userType);
+            var options = _defaultOptions.TryGetValue(type, out var value)
                 ? value
                 : Result.Failure<SlimNotificationOptions>($"Cannot find options for type '{type}'");
 
+            return options.Value.EnabledReceivers.HasFlag(receiver)
+                ? options
+                : Result.Failure<SlimNotificationOptions>($"Cannot find options for type '{type}' and receiver '{receiver}'");
 
-        public static Dictionary<NotificationTypes, SlimNotificationOptions> GetDefaultOptions()
-            => _defaultOptions;
+
+            static ReceiverTypes GetReceiver(ApiCallerTypes userType)
+                => userType switch
+                {
+                    ApiCallerTypes.Admin => ReceiverTypes.AdminPanel,
+                    ApiCallerTypes.Agent => ReceiverTypes.AgentApp,
+                    _ => throw new System.NotImplementedException()
+                };
+        }
+
+
+        public static Dictionary<NotificationTypes, SlimNotificationOptions> GetDefaultOptions(ReceiverTypes receiver)
+            => _defaultOptions.Where(o => o.Value.EnabledReceivers.HasFlag(receiver))
+                .ToDictionary(p => p.Key, p => p.Value);
 
 
         private static readonly Dictionary<NotificationTypes, SlimNotificationOptions> _defaultOptions = new()
         {
             // Booking
-            [NotificationTypes.BookingVoucher] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = true },
-            [NotificationTypes.BookingInvoice] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = true },
-            [NotificationTypes.DeadlineApproaching] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },
-            [NotificationTypes.SuccessfulPaymentReceipt] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = true },
-            [NotificationTypes.BookingDuePaymentDate] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },
-            [NotificationTypes.BookingCancelled] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },
-            [NotificationTypes.BookingFinalized] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },
-            [NotificationTypes.BookingStatusChanged] = new() { EnabledProtocols = ProtocolTypes.WebSocket, IsMandatory = false },
+            [NotificationTypes.BookingVoucher] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = true,
+                EnabledReceivers = ReceiverTypes.AgentApp },
+            [NotificationTypes.BookingInvoice] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = true, 
+                EnabledReceivers = ReceiverTypes.AdminPanel | ReceiverTypes.AgentApp },
+            [NotificationTypes.DeadlineApproaching] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false,
+                EnabledReceivers = ReceiverTypes.AgentApp },
+            [NotificationTypes.SuccessfulPaymentReceipt] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = true,
+                EnabledReceivers = ReceiverTypes.AdminPanel | ReceiverTypes.AgentApp },
+            [NotificationTypes.BookingDuePaymentDate] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },    // TODO: Need clarify, now not used
+            [NotificationTypes.BookingCancelled] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false, 
+                EnabledReceivers = ReceiverTypes.AdminPanel | ReceiverTypes.AgentApp },
+            [NotificationTypes.BookingFinalized] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false, 
+                EnabledReceivers = ReceiverTypes.AdminPanel | ReceiverTypes.AgentApp },
+            [NotificationTypes.BookingStatusChanged] = new() { EnabledProtocols = ProtocolTypes.WebSocket, IsMandatory = false, 
+                EnabledReceivers = ReceiverTypes.AdminPanel | ReceiverTypes.AgentApp },
             // Accounts
-            [NotificationTypes.CreditCardPaymentReceived] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },
-            [NotificationTypes.AccountBalanceReplenished] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },
+            [NotificationTypes.CreditCardPaymentReceived] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false, 
+                EnabledReceivers = ReceiverTypes.AgentApp },
+            [NotificationTypes.AccountBalanceReplenished] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false, 
+                EnabledReceivers = ReceiverTypes.AgentApp },
             // Counterparty
-            [NotificationTypes.AgentInvitation] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = true },
-            [NotificationTypes.ChildAgencyInvitation] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = true },
-            [NotificationTypes.AgentSuccessfulRegistration] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },
-            [NotificationTypes.ChildAgencySuccessfulRegistration] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },
-            [NotificationTypes.AgencyManagement] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false },
+            [NotificationTypes.AgentInvitation] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = true, 
+                EnabledReceivers = ReceiverTypes.AgentApp },
+            [NotificationTypes.ChildAgencyInvitation] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = true, 
+                EnabledReceivers = ReceiverTypes.AgentApp },
+            [NotificationTypes.AgentSuccessfulRegistration] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false, 
+                EnabledReceivers = ReceiverTypes.AgentApp },
+            [NotificationTypes.ChildAgencySuccessfulRegistration] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false, 
+                EnabledReceivers = ReceiverTypes.AgentApp },
+            [NotificationTypes.AgencyManagement] = new() { EnabledProtocols = ProtocolTypes.Email | ProtocolTypes.WebSocket, IsMandatory = false }, // TODO: Will be used in the task AA-303
             // Administrator
-            [NotificationTypes.AdministratorInvitation] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = true },
-            [NotificationTypes.MasterAgentSuccessfulRegistration] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = true },  // TODO: The WebSocket protocol will be added in the task AA-257
-            [NotificationTypes.BookingsAdministratorSummaryNotification] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = false }, // TODO: The WebSocket protocol will be added in the task AA-257
-            [NotificationTypes.BookingAdministratorPaymentsSummary] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = false },    // Need clarify
-            [NotificationTypes.BookingCancelledToReservations] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = false },   // TODO: The WebSocket protocol will be added in the task AA-257
-            [NotificationTypes.BookingFinalizedToReservations] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = false },   // TODO: The WebSocket protocol will be added in the task AA-257
-            [NotificationTypes.CreditCardPaymentReceivedAdministrator] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = false },   // TODO: The WebSocket protocol will be added in the task AA-257
-            [NotificationTypes.BookingManualCorrectionNeeded] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = false },  // Need clarify
+            [NotificationTypes.AdministratorInvitation] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = true, 
+                EnabledReceivers = ReceiverTypes.AdminPanel },
+            [NotificationTypes.MasterAgentSuccessfulRegistration] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = true, 
+                EnabledReceivers = ReceiverTypes.AdminPanel },  // TODO: The WebSocket protocol will be added in the task AA-257
+            [NotificationTypes.BookingsAdministratorSummaryNotification] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = false, 
+                EnabledReceivers = ReceiverTypes.AdminPanel }, // TODO: The WebSocket protocol will be added in the task AA-257
+            [NotificationTypes.BookingAdministratorPaymentsSummary] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = false, 
+                EnabledReceivers = ReceiverTypes.AdminPanel },    // Need clarify
+            [NotificationTypes.BookingCancelledToReservations] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = false, 
+                EnabledReceivers = ReceiverTypes.AdminPanel },   // TODO: The WebSocket protocol will be added in the task AA-257
+            [NotificationTypes.BookingFinalizedToReservations] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = false, 
+                EnabledReceivers = ReceiverTypes.AdminPanel },   // TODO: The WebSocket protocol will be added in the task AA-257
+            [NotificationTypes.CreditCardPaymentReceivedAdministrator] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = false, 
+                EnabledReceivers = ReceiverTypes.AdminPanel },   // TODO: The WebSocket protocol will be added in the task AA-257
+            [NotificationTypes.BookingManualCorrectionNeeded] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = false, 
+                EnabledReceivers = ReceiverTypes.AdminPanel },  // Need clarify
             // Other
-            [NotificationTypes.BookingSummaryReportForAgent] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = true }, // Need clarify
-            [NotificationTypes.ExternalPaymentLinks] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = true },
-            [NotificationTypes.PaymentLinkPaidNotification] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = true }
+            [NotificationTypes.BookingSummaryReportForAgent] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = true, 
+                EnabledReceivers = ReceiverTypes.AgentApp }, // Need clarify
+            [NotificationTypes.ExternalPaymentLinks] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = true,
+                EnabledReceivers = ReceiverTypes.AgentApp },
+            [NotificationTypes.PaymentLinkPaidNotification] = new() { EnabledProtocols = ProtocolTypes.Email, IsMandatory = true, 
+                EnabledReceivers = ReceiverTypes.AgentApp }
         };
     }
 }

--- a/HappyTravel.Edo.Notifications/Models/SlimNotificationOption.cs
+++ b/HappyTravel.Edo.Notifications/Models/SlimNotificationOption.cs
@@ -6,5 +6,6 @@ namespace HappyTravel.Edo.Notifications.Models
     {
         public ProtocolTypes EnabledProtocols { get; init; }
         public bool IsMandatory { get; init; }
+        public ReceiverTypes EnabledReceivers { get; init; }
     }
 }


### PR DESCRIPTION
Added receiver type to notification options. For agents, only the options are returned, the receiver of which is the agent application, for administrators - the administrative panel.