### PR TITLE
Add roles to agent invitation

### DIFF
--- a/Api/Extensions/InvitationInfoExtensions.cs
+++ b/Api/Extensions/InvitationInfoExtensions.cs
@@ -11,7 +11,7 @@ namespace HappyTravel.Edo.Api.Extensions
     {
         public static UserInvitationData ToUserInvitationData(this UserDescriptionInfo info, string email = null)
         {
-            var newInfo = new UserDescriptionInfo(info.Title, info.FirstName, info.LastName, info.Position, email ?? info.Email);
+            var newInfo = new UserDescriptionInfo(info.Title, info.FirstName, info.LastName, info.Position, email ?? info.Email, info.RoleIds);
             return new UserInvitationData(newInfo, default);
         }
 

--- a/Api/Models/Users/UserDescriptionInfo.cs
+++ b/Api/Models/Users/UserDescriptionInfo.cs
@@ -7,13 +7,14 @@ namespace HappyTravel.Edo.Api.Models.Users
     {
         [JsonConstructor]
         public UserDescriptionInfo(string title, string firstName, string lastName,
-            string position, string email)
+            string position, string email, int[] roleIds)
         {
             Title = title;
             FirstName = firstName;
             LastName = lastName;
             Position = position;
             Email = email;
+            RoleIds = roleIds;
         }
 
 
@@ -44,6 +45,11 @@ namespace HappyTravel.Edo.Api.Models.Users
         ///     Email
         /// </summary>
         public string Email { get; }
+        
+        /// <summary>
+        ///     Role ids assigned to user
+        /// </summary>
+        public int[] RoleIds { get; }
 
 
         public override int GetHashCode()

--- a/Api/Models/Users/UserDescriptionInfo.cs
+++ b/Api/Models/Users/UserDescriptionInfo.cs
@@ -7,14 +7,14 @@ namespace HappyTravel.Edo.Api.Models.Users
     {
         [JsonConstructor]
         public UserDescriptionInfo(string title, string firstName, string lastName,
-            string position, string email, int[] roleIds)
+            string position, string email, int[] roleIds = null)
         {
             Title = title;
             FirstName = firstName;
             LastName = lastName;
             Position = position;
             Email = email;
-            RoleIds = roleIds;
+            RoleIds = roleIds ?? System.Array.Empty<int>();
         }
 
 

--- a/Api/Services/Agents/AgentRegistrationService.cs
+++ b/Api/Services/Agents/AgentRegistrationService.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Infrastructure;
@@ -42,6 +43,7 @@ namespace HappyTravel.Edo.Api.Services.Agents
         {
             return Result.Success()
                 .Ensure(IsIdentityPresent, "User should have identity")
+                .Ensure(AllProvidedRolesExist, "Provided roles doesn't exist")
                 .BindWithTransaction(_context, () => Result.Success()
                     .Bind(CreateCounterparty)
                     .Bind(CreateAgent)
@@ -50,7 +52,17 @@ namespace HappyTravel.Edo.Api.Services.Agents
                 .Bind(SendRegistrationMailToAdmins)
                 .OnFailure(LogFailure);
 
+
             bool IsIdentityPresent() => !string.IsNullOrWhiteSpace(externalIdentity);
+
+            
+            bool AllProvidedRolesExist()
+            {
+                var allRoleIds = _context.AgentRoles
+                    .Select(x => x.Id)
+                    .ToList();
+                return agentData.RoleIds.All(roleId => allRoleIds.Contains(roleId));
+            }
             
 
             Task<Result<CounterpartyInfo>> CreateCounterparty() 
@@ -73,7 +85,8 @@ namespace HappyTravel.Edo.Api.Services.Agents
                 await AddAgentAgencyRelation(agent,
                     AgentAgencyRelationTypes.Master,
                     PermissionSets.Master,
-                    rootAgency.Id);
+                    rootAgency.Id,
+                    agentData.RoleIds);
             }
 
 
@@ -126,7 +139,7 @@ namespace HappyTravel.Edo.Api.Services.Agents
         }
 
 
-        private Task AddAgentAgencyRelation(Agent agent, AgentAgencyRelationTypes relationType, InAgencyPermissions permissions, int agencyId)
+        private Task AddAgentAgencyRelation(Agent agent, AgentAgencyRelationTypes relationType, InAgencyPermissions permissions, int agencyId, int[] agentRoleIds)
         {
             _context.AgentAgencyRelations.Add(new AgentAgencyRelation
             {
@@ -134,7 +147,8 @@ namespace HappyTravel.Edo.Api.Services.Agents
                 Type = relationType,
                 InAgencyPermissions = permissions,
                 AgencyId = agencyId,
-                IsActive = true
+                IsActive = true,
+                AgentRoleIds = agentRoleIds
             });
 
             return _context.SaveChangesAsync();

--- a/Api/Services/Agents/AgentRegistrationService.cs
+++ b/Api/Services/Agents/AgentRegistrationService.cs
@@ -58,6 +58,10 @@ namespace HappyTravel.Edo.Api.Services.Agents
             
             bool AllProvidedRolesExist()
             {
+                // TODO remove when front will send role ids
+                if (agentData.RoleIds.Length == 0)
+                    return true;
+                
                 var allRoleIds = _context.AgentRoles
                     .Select(x => x.Id)
                     .ToList();

--- a/Api/Services/Invitations/AgentInvitationAcceptService.cs
+++ b/Api/Services/Invitations/AgentInvitationAcceptService.cs
@@ -106,10 +106,15 @@ namespace HappyTravel.Edo.Api.Services.Invitations
 
             bool AllProvidedRolesExist(AcceptPipeValues values)
             {
+                var providedRoleIds = filledData.UserRegistrationInfo.RoleIds;
+                
+                // TODO remove when front will send role ids
+                if (providedRoleIds.Length == 0)
+                    return true;
+                
                 var allRoleIds = _context.AgentRoles
                     .Select(x => x.Id)
                     .ToList();
-                var providedRoleIds = filledData.UserRegistrationInfo.RoleIds;
                 return providedRoleIds.All(roleId => allRoleIds.Contains(roleId));
             }
 

--- a/Api/Services/Invitations/AgentInvitationAcceptService.cs
+++ b/Api/Services/Invitations/AgentInvitationAcceptService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.AdministratorServices;
@@ -80,7 +80,8 @@ namespace HappyTravel.Edo.Api.Services.Invitations
                     .Ensure(IsInvitationTypeCorrect, "Incorrect invitation type")
                     .Ensure(IsAgencyIdFilled, "Could not find inviter's agency id")
                     .Ensure(IsEmailFilled, "Agent email required")
-                    .Ensure(IsAgentEmailUnique, "Agent with this email already exists");
+                    .Ensure(IsAgentEmailUnique, "Agent with this email already exists")
+                    .Ensure(AllProvidedRolesExist, "Provided role doesn't exist");
 
 
             bool IsIdentityPresent(AcceptPipeValues _)
@@ -101,6 +102,16 @@ namespace HappyTravel.Edo.Api.Services.Invitations
 
             async Task<bool> IsAgentEmailUnique(AcceptPipeValues values)
                 => !await _context.Agents.AnyAsync(a => a.Email == email);
+
+
+            bool AllProvidedRolesExist(AcceptPipeValues values)
+            {
+                var allRoleIds = _context.AgentRoles
+                    .Select(x => x.Id)
+                    .ToList();
+                var providedRoleIds = filledData.UserRegistrationInfo.RoleIds;
+                return providedRoleIds.All(roleId => allRoleIds.Contains(roleId));
+            }
 
 
             Task SaveAccepted(AcceptPipeValues _)


### PR DESCRIPTION
Resolves https://github.com/happy-travel/agent-app-project/issues/365

The invitation data stored in UserDescriptionInfo will also contain RoleIds - ids of assigned roles.
As this class is used for both agent's and admin's registration, the name will be more generic - just RoleIds, not AgentRoleIds or AdminRoleIds.

This data is provided by the front and then stored inside JSON for later use.