### PR TITLE
Feature/aa 401 add api for displaying actual hotel confirmation code and history

### DIFF
--- a/Api/Controllers/AdministratorControllers/BookingsController.cs
+++ b/Api/Controllers/AdministratorControllers/BookingsController.cs
@@ -119,7 +119,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         /// </summary>
         /// <param name="referenceCode">Booking reference code for retrieving confirmation change history</param>
         /// <returns>List of booking confirmation change events</returns>
-        [HttpGet("bookings/{referenceCode}/confirmation-history")]
+        [HttpGet("accommodations/bookings/reference-code/{referenceCode}/confirmation-history")]
         [ProducesResponseType(typeof(List<BookingConfirmationHistoryEntry>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.BookingManagement)]

--- a/Api/Controllers/AdministratorControllers/BookingsController.cs
+++ b/Api/Controllers/AdministratorControllers/BookingsController.cs
@@ -115,6 +115,21 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
 
 
         /// <summary>
+        ///     Gets booking confirmation changes history
+        /// </summary>
+        /// <param name="referenceCode">Booking reference code for retrieving confirmation change history</param>
+        /// <returns>List of booking confirmation change events</returns>
+        [HttpGet("bookings/{referenceCode}/confirmation-history")]
+        [ProducesResponseType(typeof(List<BookingConfirmationHistoryEntry>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
+        [AdministratorPermissions(AdministratorPermissions.BookingManagement)]
+        public async Task<IActionResult> GetBookingConfirmationCodeHistory([FromRoute] string referenceCode)
+        {
+            return OkOrBadRequest(await _bookingInfoService.GetBookingConfirmationHistory(referenceCode));
+        }
+
+
+        /// <summary>
         ///     Discards accommodation booking by admin.
         /// </summary>
         /// <param name="bookingId">Id of booking to cancel</param>

--- a/Api/Controllers/AdministratorControllers/BookingsController.cs
+++ b/Api/Controllers/AdministratorControllers/BookingsController.cs
@@ -119,7 +119,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         /// </summary>
         /// <param name="referenceCode">Booking reference code for retrieving confirmation change history</param>
         /// <returns>List of booking confirmation change events</returns>
-        [HttpGet("accommodations/bookings/reference-code/{referenceCode}/confirmation-history")]
+        [HttpGet("accommodations/bookings/{referenceCode}/confirmation-history")]
         [ProducesResponseType(typeof(List<BookingConfirmationHistoryEntry>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.BookingManagement)]

--- a/Api/Controllers/AgentControllers/BookingsController.cs
+++ b/Api/Controllers/AgentControllers/BookingsController.cs
@@ -343,7 +343,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         /// </summary>
         /// <param name="referenceCode">Booking reference code for retrieving confirmation change history</param>
         /// <returns>List of booking confirmation change events</returns>
-        [HttpGet("refcode/{referenceCode}/confirmation-history")]
+        [HttpGet("reference-code/{referenceCode}/confirmation-history")]
         [ProducesResponseType(typeof(List<BookingConfirmationHistoryEntry>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         [MinCounterpartyState(CounterpartyStates.FullAccess)]

--- a/Api/Controllers/AgentControllers/BookingsController.cs
+++ b/Api/Controllers/AgentControllers/BookingsController.cs
@@ -338,6 +338,23 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         }
 
 
+        /// <summary>
+        ///     Gets booking confirmation changes history
+        /// </summary>
+        /// <param name="referenceCode">Booking reference code for retrieving confirmation change history</param>
+        /// <returns>List of booking status change events</returns>
+        [HttpGet("{bookingId}/status-history")]
+        [ProducesResponseType(typeof(List<BookingConfirmationHistoryEntry>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
+        [MinCounterpartyState(CounterpartyStates.FullAccess)]
+        [InAgencyPermissions(InAgencyPermissions.AccommodationBooking)]
+        [AgentRequired]
+        public async Task<IActionResult> GetBookingConfirmationCodeHistory([FromRoute] string referenceCode)
+        {
+            return OkOrBadRequest(await _bookingInfoService.GetConfirmationHistory(referenceCode));
+        }
+
+
         private readonly IFinancialAccountBookingFlow _financialAccountBookingFlow;
         private readonly IBankCreditCardBookingFlow _bankCreditCardBookingFlow;
         private readonly IOfflinePaymentBookingFlow _offlinePaymentBookingFlow;

--- a/Api/Controllers/AgentControllers/BookingsController.cs
+++ b/Api/Controllers/AgentControllers/BookingsController.cs
@@ -342,8 +342,8 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         ///     Gets booking confirmation changes history
         /// </summary>
         /// <param name="referenceCode">Booking reference code for retrieving confirmation change history</param>
-        /// <returns>List of booking status change events</returns>
-        [HttpGet("{bookingId}/status-history")]
+        /// <returns>List of booking confirmation change events</returns>
+        [HttpGet("refcode/{referenceCode}/confirmation-history")]
         [ProducesResponseType(typeof(List<BookingConfirmationHistoryEntry>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         [MinCounterpartyState(CounterpartyStates.FullAccess)]
@@ -351,7 +351,7 @@ namespace HappyTravel.Edo.Api.Controllers.AgentControllers
         [AgentRequired]
         public async Task<IActionResult> GetBookingConfirmationCodeHistory([FromRoute] string referenceCode)
         {
-            return OkOrBadRequest(await _bookingInfoService.GetConfirmationHistory(referenceCode));
+            return OkOrBadRequest(await _bookingInfoService.GetBookingConfirmationHistory(referenceCode));
         }
 
 

--- a/Api/Controllers/PropertyOwnerControllers/BookingConfirmationController.cs
+++ b/Api/Controllers/PropertyOwnerControllers/BookingConfirmationController.cs
@@ -22,22 +22,13 @@ namespace HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers
         ///     Gets an actual booking status and confirmation code
         /// </summary>
         /// <param name="referenceCode">Booking reference code</param>
-        /// <returns>Agency availability search settings</returns>
+        /// <returns>Booking status and property owner confirmation code</returns>
         [HttpGet("{referenceCode}")]
-        [ProducesResponseType(typeof(AgencyAccommodationBookingSettingsInfo), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(SlimBookingConfirmation), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
-        [ProducesResponseType((int)HttpStatusCode.NoContent)]
-        [AdministratorPermissions(AdministratorPermissions.AgentManagement)]
         public async Task<IActionResult> Get([FromRoute] string referenceCode)
         {
-            var (_, isFailure, settings, error) = await _bookingConfirmationService.Get(referenceCode);
-            if (isFailure)
-                return BadRequest(ProblemDetailsBuilder.Build(error));
-
-            if (settings == default)
-                return NoContent();
-
-            return Ok(settings.ToAgencyAccommodationBookingSettingsInfo());
+            return OkOrBadRequest(await _bookingConfirmationService.Get(referenceCode));
         }
 
 

--- a/Api/Controllers/PropertyOwnerControllers/BookingConfirmationController.cs
+++ b/Api/Controllers/PropertyOwnerControllers/BookingConfirmationController.cs
@@ -1,6 +1,9 @@
 ﻿using HappyTravel.Edo.Api.Models.PropertyOwners;
+using HappyTravel.Edo.Api.Services.Accommodations.Bookings.Management;
 using HappyTravel.Edo.Api.Services.PropertyOwners;
+using HappyTravel.Edo.Data.Bookings;
 using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -12,9 +15,10 @@ namespace HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers
     [Produces("application/json")]
     public class BookingConfirmationController : BaseController
     {
-        public BookingConfirmationController(IBookingConfirmationService bookingConfirmationService)
+        public BookingConfirmationController(IBookingConfirmationService bookingConfirmationService, IBookingInfoService bookingInfoService)
         {
             _bookingConfirmationService = bookingConfirmationService;
+            _bookingInfoService = bookingInfoService;
         }
 
 
@@ -33,6 +37,20 @@ namespace HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers
 
 
         /// <summary>
+        ///     Gets booking confirmation changes history
+        /// </summary>
+        /// <param name="referenceCode">Booking reference code for retrieving confirmation change history</param>
+        /// <returns>List of booking confirmation change events</returns>
+        [HttpGet("{referenceCode}/confirmation-history")]
+        [ProducesResponseType(typeof(List<BookingConfirmationHistoryEntry>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
+        public async Task<IActionResult> GetBookingConfirmationCodeHistory([FromRoute] string referenceCode)
+        {
+            return OkOrBadRequest(await _bookingInfoService.GetBookingConfirmationHistory(referenceCode));
+        }
+
+
+        /// <summary>
         ///     Updates booking status and hotel confirmation code
         /// </summary>
         /// <param name="referenceCode">Booking reference code</param>
@@ -46,5 +64,6 @@ namespace HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers
 
 
         private readonly IBookingConfirmationService _bookingConfirmationService;
+        private readonly IBookingInfoService _bookingInfoService;
     }
 }

--- a/Api/Controllers/PropertyOwnerControllers/BookingConfirmationController.cs
+++ b/Api/Controllers/PropertyOwnerControllers/BookingConfirmationController.cs
@@ -27,7 +27,7 @@ namespace HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers
         /// </summary>
         /// <param name="referenceCode">Booking reference code</param>
         /// <returns>Booking status and property owner confirmation code</returns>
-        [HttpGet("{referenceCode}")]
+        [HttpGet("reference-code/{referenceCode}")]
         [ProducesResponseType(typeof(SlimBookingConfirmation), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         public async Task<IActionResult> Get([FromRoute] string referenceCode)
@@ -41,7 +41,7 @@ namespace HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers
         /// </summary>
         /// <param name="referenceCode">Booking reference code for retrieving confirmation change history</param>
         /// <returns>List of booking confirmation change events</returns>
-        [HttpGet("{referenceCode}/confirmation-history")]
+        [HttpGet("reference-code/{referenceCode}/confirmation-history")]
         [ProducesResponseType(typeof(List<BookingConfirmationHistoryEntry>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         public async Task<IActionResult> GetBookingConfirmationCodeHistory([FromRoute] string referenceCode)
@@ -56,7 +56,7 @@ namespace HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers
         /// <param name="referenceCode">Booking reference code</param>
         /// <param name="bookingConfirmation">Booking confirmation data</param>
         /// <returns></returns>
-        [HttpPut("{referenceCode}")]
+        [HttpPut("reference-code/{referenceCode}")]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         public async Task<IActionResult> Update([FromRoute] string referenceCode, [FromBody] BookingConfirmation bookingConfirmation)

--- a/Api/Controllers/PropertyOwnerControllers/BookingConfirmationController.cs
+++ b/Api/Controllers/PropertyOwnerControllers/BookingConfirmationController.cs
@@ -27,7 +27,7 @@ namespace HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers
         /// </summary>
         /// <param name="referenceCode">Booking reference code</param>
         /// <returns>Booking status and property owner confirmation code</returns>
-        [HttpGet("reference-code/{referenceCode}")]
+        [HttpGet("{referenceCode}")]
         [ProducesResponseType(typeof(SlimBookingConfirmation), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         public async Task<IActionResult> Get([FromRoute] string referenceCode)
@@ -41,7 +41,7 @@ namespace HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers
         /// </summary>
         /// <param name="referenceCode">Booking reference code for retrieving confirmation change history</param>
         /// <returns>List of booking confirmation change events</returns>
-        [HttpGet("reference-code/{referenceCode}/confirmation-history")]
+        [HttpGet("{referenceCode}/confirmation-history")]
         [ProducesResponseType(typeof(List<BookingConfirmationHistoryEntry>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         public async Task<IActionResult> GetBookingConfirmationCodeHistory([FromRoute] string referenceCode)
@@ -56,7 +56,7 @@ namespace HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers
         /// <param name="referenceCode">Booking reference code</param>
         /// <param name="bookingConfirmation">Booking confirmation data</param>
         /// <returns></returns>
-        [HttpPut("reference-code/{referenceCode}")]
+        [HttpPut("{referenceCode}")]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         public async Task<IActionResult> Update([FromRoute] string referenceCode, [FromBody] BookingConfirmation bookingConfirmation)

--- a/Api/Controllers/PropertyOwnerControllers/BookingConfirmationController.cs
+++ b/Api/Controllers/PropertyOwnerControllers/BookingConfirmationController.cs
@@ -19,6 +19,29 @@ namespace HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers
 
 
         /// <summary>
+        ///     Gets an actual booking status and confirmation code
+        /// </summary>
+        /// <param name="referenceCode">Booking reference code</param>
+        /// <returns>Agency availability search settings</returns>
+        [HttpGet("{referenceCode}")]
+        [ProducesResponseType(typeof(AgencyAccommodationBookingSettingsInfo), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType((int)HttpStatusCode.NoContent)]
+        [AdministratorPermissions(AdministratorPermissions.AgentManagement)]
+        public async Task<IActionResult> Get([FromRoute] string referenceCode)
+        {
+            var (_, isFailure, settings, error) = await _bookingConfirmationService.Get(referenceCode);
+            if (isFailure)
+                return BadRequest(ProblemDetailsBuilder.Build(error));
+
+            if (settings == default)
+                return NoContent();
+
+            return Ok(settings.ToAgencyAccommodationBookingSettingsInfo());
+        }
+
+
+        /// <summary>
         ///     Updates booking status and hotel confirmation code
         /// </summary>
         /// <param name="bookingConfirmation">Settings</param>

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -1171,6 +1171,13 @@
             <param name="bookingId">Booking ID for retrieving status change history</param>
             <returns>List of booking status change events</returns>
         </member>
+        <member name="M:HappyTravel.Edo.Api.Controllers.AgentControllers.BookingsController.GetBookingConfirmationCodeHistory(System.String)">
+            <summary>
+                Gets booking confirmation changes history
+            </summary>
+            <param name="referenceCode">Booking reference code for retrieving confirmation change history</param>
+            <returns>List of booking confirmation change events</returns>
+        </member>
         <member name="M:HappyTravel.Edo.Api.Controllers.AgentControllers.BookingSupportingDocumentsController.SendBookingVoucher(System.Int32,HappyTravel.Edo.Api.Models.Emailing.SendBookingDocumentRequest)">
             <summary>
                 Sends booking voucher to an email.

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -309,6 +309,13 @@
             <param name="referenceCode">Booking reference code</param>
             <returns>Booking Info</returns>
         </member>
+        <member name="M:HappyTravel.Edo.Api.Controllers.AdministratorControllers.BookingsController.GetBookingConfirmationCodeHistory(System.String)">
+            <summary>
+                Gets booking confirmation changes history
+            </summary>
+            <param name="referenceCode">Booking reference code for retrieving confirmation change history</param>
+            <returns>List of booking confirmation change events</returns>
+        </member>
         <member name="M:HappyTravel.Edo.Api.Controllers.AdministratorControllers.BookingsController.Discard(System.Int32)">
             <summary>
                 Discards accommodation booking by admin.
@@ -1497,6 +1504,13 @@
             </summary>
             <param name="referenceCode">Booking reference code</param>
             <returns>Booking status and property owner confirmation code</returns>
+        </member>
+        <member name="M:HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers.BookingConfirmationController.GetBookingConfirmationCodeHistory(System.String)">
+            <summary>
+                Gets booking confirmation changes history
+            </summary>
+            <param name="referenceCode">Booking reference code for retrieving confirmation change history</param>
+            <returns>List of booking confirmation change events</returns>
         </member>
         <member name="M:HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers.BookingConfirmationController.Update(System.String,HappyTravel.Edo.Api.Models.PropertyOwners.BookingConfirmation)">
             <summary>

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -1484,6 +1484,13 @@
             </summary>
             <returns></returns>
         </member>
+        <member name="M:HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers.BookingConfirmationController.Get(System.String)">
+            <summary>
+                Gets an actual booking status and confirmation code
+            </summary>
+            <param name="referenceCode">Booking reference code</param>
+            <returns>Booking status and property owner confirmation code</returns>
+        </member>
         <member name="M:HappyTravel.Edo.Api.Controllers.PropertyOwnerControllers.BookingConfirmationController.Update(System.String,HappyTravel.Edo.Api.Models.PropertyOwners.BookingConfirmation)">
             <summary>
                 Updates booking status and hotel confirmation code

--- a/Api/Models/Bookings/AccommodationBookingDetails.cs
+++ b/Api/Models/Bookings/AccommodationBookingDetails.cs
@@ -15,7 +15,8 @@ namespace HappyTravel.Edo.Api.Models.Bookings
         public AccommodationBookingDetails(string referenceCode, string agentReference, BookingStatuses status, int numberOfNights,
             DateTime checkInDate, DateTime checkOutDate, AccommodationLocation location, ContactInfo contactInfo,
             string accommodationId, string accommodationName, AccommodationInfo accommodationInfo, DateTime? deadlineDate,
-            List<BookedRoom> roomDetails, int numberOfPassengers, List<CancellationPolicy> cancellationPolicies, DateTime created)
+            List<BookedRoom> roomDetails, int numberOfPassengers, List<CancellationPolicy> cancellationPolicies, DateTime created,
+            string propertyOwnerConfirmationCode)
         {
             ReferenceCode = referenceCode;
             AgentReference = agentReference;
@@ -33,6 +34,7 @@ namespace HappyTravel.Edo.Api.Models.Bookings
             CancellationPolicies = cancellationPolicies;
             Created = created;
             RoomDetails = roomDetails ?? new List<BookedRoom>(0);
+            PropertyOwnerConfirmationCode = propertyOwnerConfirmationCode;
         }
         
 
@@ -65,5 +67,6 @@ namespace HappyTravel.Edo.Api.Models.Bookings
         public List<CancellationPolicy> CancellationPolicies { get; }
         public DateTime Created { get; }
         public List<BookedRoom> RoomDetails { get; }
+        public string PropertyOwnerConfirmationCode { get; }
     }
 }

--- a/Api/Models/PropertyOwners/SlimBookingConfirmation.cs
+++ b/Api/Models/PropertyOwners/SlimBookingConfirmation.cs
@@ -1,0 +1,11 @@
+﻿using HappyTravel.Edo.Common.Enums;
+
+namespace HappyTravel.Edo.Api.Models.PropertyOwners
+{
+    public readonly struct SlimBookingConfirmation
+    {
+        public string ReferenceCode { get; init; }
+        public string ConfirmationCode { get; init; }
+        public BookingConfirmationStatuses Status { get; init; }
+    }
+}

--- a/Api/Models/PropertyOwners/SlimBookingConfirmation.cs
+++ b/Api/Models/PropertyOwners/SlimBookingConfirmation.cs
@@ -6,6 +6,6 @@ namespace HappyTravel.Edo.Api.Models.PropertyOwners
     {
         public string ReferenceCode { get; init; }
         public string ConfirmationCode { get; init; }
-        public BookingConfirmationStatuses Status { get; init; }
+        public BookingStatuses Status { get; init; }
     }
 }

--- a/Api/Services/Accommodations/Bookings/Management/BookingInfoService.cs
+++ b/Api/Services/Accommodations/Bookings/Management/BookingInfoService.cs
@@ -208,7 +208,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Management
                     roomDetails: booking.Rooms,
                     numberOfPassengers: passengerNumber,
                     cancellationPolicies: booking.CancellationPolicies,
-                    created: booking.Created);
+                    created: booking.Created,
+                    propertyOwnerConfirmationCode: booking.PropertyOwnerConfirmationCode);
             }
             
             

--- a/Api/Services/Accommodations/Bookings/Management/BookingInfoService.cs
+++ b/Api/Services/Accommodations/Bookings/Management/BookingInfoService.cs
@@ -161,6 +161,17 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Management
         }
 
 
+        public async Task<Result<List<BookingConfirmationHistoryEntry>>> GetBookingConfirmationHistory(string referenceCode)
+        {
+            var history = await _context.BookingConfirmationHistory
+                .Where(bch => bch.ReferenceCode == referenceCode)
+                .OrderBy(bch => bch.Id)
+                .ToListAsync();
+
+            return history ?? new(0);
+        }
+
+
         private async Task<Result<AccommodationBookingInfo>> ConvertToBookingInfo(Booking booking, string languageCode, AgentContext? agentContext = null)
         {
             var (_, isFailure, accommodation, error) = await _accommodationService.Get(booking.HtId, languageCode);

--- a/Api/Services/Accommodations/Bookings/Management/BookingInfoService.cs
+++ b/Api/Services/Accommodations/Bookings/Management/BookingInfoService.cs
@@ -168,7 +168,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Management
                 .OrderBy(bch => bch.Id)
                 .ToListAsync();
 
-            return history ?? bookingConfirmationHistoryEmpty;
+            return history ?? emptyBookingConfirmationHistory;
         }
 
 
@@ -262,7 +262,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Management
             BookingStatuses.Created,
             BookingStatuses.Invalid
         };
-        private static readonly List<BookingConfirmationHistoryEntry> bookingConfirmationHistoryEmpty = new(0);
+        private static readonly List<BookingConfirmationHistoryEntry> emptyBookingConfirmationHistory = new(0);
 
         private readonly EdoContext _context;
         private readonly IBookingRecordManager _bookingRecordManager;

--- a/Api/Services/Accommodations/Bookings/Management/BookingInfoService.cs
+++ b/Api/Services/Accommodations/Bookings/Management/BookingInfoService.cs
@@ -168,7 +168,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Management
                 .OrderBy(bch => bch.Id)
                 .ToListAsync();
 
-            return history ?? new(0);
+            return history ?? bookingConfirmationHistoryEmpty;
         }
 
 
@@ -262,7 +262,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Management
             BookingStatuses.Created,
             BookingStatuses.Invalid
         };
-        
+        private static readonly List<BookingConfirmationHistoryEntry> bookingConfirmationHistoryEmpty = new(0);
+
         private readonly EdoContext _context;
         private readonly IBookingRecordManager _bookingRecordManager;
         private readonly IAccommodationService _accommodationService;

--- a/Api/Services/Accommodations/Bookings/Management/IBookingInfoService.cs
+++ b/Api/Services/Accommodations/Bookings/Management/IBookingInfoService.cs
@@ -23,5 +23,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Management
         Task<Result<Booking>> GetAgentsBooking(string referenceCode, AgentContext agentContext);
 
         Task<Result<List<BookingStatusHistoryEntry>>> GetBookingStatusHistory(int bookingId, AgentContext agent);
+
+        Task<Result<List<BookingConfirmationHistoryEntry>>> GetBookingConfirmationHistory(string referenceCode);
     }
 }

--- a/Api/Services/PropertyOwners/BookingConfirmationService.cs
+++ b/Api/Services/PropertyOwners/BookingConfirmationService.cs
@@ -89,7 +89,6 @@ namespace HappyTravel.Edo.Api.Services.PropertyOwners
                     ReferenceCode = referenceCode,
                     ConfirmationCode = bookingConfirmation.ConfirmationCode,
                     Status = bookingConfirmation.Status,
-                    Comment = bookingConfirmation.Comment,
                     Initiator = bookingConfirmation.Initiator,
                     CreatedAt = bookingConfirmation.CreatedAt
                 });

--- a/Api/Services/PropertyOwners/IBookingConfirmationService.cs
+++ b/Api/Services/PropertyOwners/IBookingConfirmationService.cs
@@ -6,6 +6,7 @@ namespace HappyTravel.Edo.Api.Services.PropertyOwners
 {
     public interface IBookingConfirmationService
     {
+        Task<Result<SlimBookingConfirmation>> Get(string referenceCode);
         Task<Result> Update(BookingConfirmation bookingConfirmation);
     }
 }


### PR DESCRIPTION
Added endpoint to get actual hotel confirmation code and status for hotel confirmation page. Hotel confirmation code added to AccommodationBookingDetails for accept in admin panel (maybe in agent app too). Added endpoints to get hotel confirmation history for agents, admins and property owner employees.