### PR TITLE
Feature/aa 472 counterparty details response for the admin panel not contains location info

### DIFF
--- a/Api/AdministratorServices/CounterpartyManagementService.cs
+++ b/Api/AdministratorServices/CounterpartyManagementService.cs
@@ -141,6 +141,19 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                 counterpartyToUpdate.PreferredPaymentMethod = changedCounterpartyInfo.PreferredPaymentMethod;
                 counterpartyToUpdate.Updated = _dateTimeProvider.UtcNow();
 
+                if (counterpartyToUpdate.State == CounterpartyStates.PendingVerification || counterpartyToUpdate.State == CounterpartyStates.ReadOnly)
+                {
+                    counterpartyToUpdate.Address = changedCounterpartyInfo.Address;
+                    counterpartyToUpdate.BillingEmail = changedCounterpartyInfo.BillingEmail;
+                    counterpartyToUpdate.City = changedCounterpartyInfo.City;
+                    counterpartyToUpdate.CountryCode = changedCounterpartyInfo.CountryCode;
+                    counterpartyToUpdate.Fax = changedCounterpartyInfo.Fax;
+                    counterpartyToUpdate.Phone = changedCounterpartyInfo.Phone;
+                    counterpartyToUpdate.PostalCode = changedCounterpartyInfo.PostalCode;
+                    counterpartyToUpdate.Website = changedCounterpartyInfo.Website;
+                    counterpartyToUpdate.VatNumber = changedCounterpartyInfo.VatNumber;
+                }
+
                 _context.Counterparties.Update(counterpartyToUpdate);
                 await _context.SaveChangesAsync();
 

--- a/Api/AdministratorServices/CounterpartyManagementService.cs
+++ b/Api/AdministratorServices/CounterpartyManagementService.cs
@@ -47,7 +47,7 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                 select cp.ToCounterpartyInfo(c.Names, languageCode, null))
                     .SingleOrDefaultAsync();
 
-            if (counterpartyInfo.Id == 0)
+            if (counterpartyInfo.Id == default)
                 return Result.Failure<CounterpartyInfo>("Could not find counterparty with specified id");
 
             return counterpartyInfo;

--- a/Api/AdministratorServices/CounterpartyManagementService.cs
+++ b/Api/AdministratorServices/CounterpartyManagementService.cs
@@ -38,19 +38,23 @@ namespace HappyTravel.Edo.Api.AdministratorServices
         }
 
 
-        public async Task<Result<CounterpartyInfo>> Get(int counterpartyId)
+        public async Task<Result<CounterpartyInfo>> Get(int counterpartyId, string languageCode = LocalizationHelper.DefaultLanguageCode)
         {
-            var counterparty = await _context.Counterparties
-                .Where(cp => cp.Id == counterpartyId)
-                .SingleOrDefaultAsync();
-            if (counterparty == default)
+            var counterpartyInfo = await 
+                (from cp in _context.Counterparties
+                join c in _context.Countries on cp.CountryCode equals c.Code
+                where cp.Id == counterpartyId
+                select cp.ToCounterpartyInfo(c.Names, languageCode, null))
+                    .SingleOrDefaultAsync();
+
+            if (counterpartyInfo.Equals(default))
                 return Result.Failure<CounterpartyInfo>("Could not find counterparty with specified id");
 
-            return ToCounterpartyInfo(counterparty);
+            return counterpartyInfo;
         }
 
 
-        public async Task<List<CounterpartyInfo>> Get()
+        public async Task<List<CounterpartySlimInfo>> Get()
         {
             var counterparties = await (from cp in _context.Counterparties
                 join formula in _context.DisplayMarkupFormulas on new
@@ -71,7 +75,7 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                     MarkupFormula = markupFormula == null ? null : markupFormula.DisplayFormula
                 }).ToListAsync();
 
-            return counterparties.Select(c => ToCounterpartyInfo(c.Counterparty, c.MarkupFormula)).ToList();
+            return counterparties.Select(c => ToCounterpartySlimInfo(c.Counterparty, c.MarkupFormula)).ToList();
         }
 
 
@@ -244,7 +248,7 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                 new CounterpartyActivityStatusChangeEventData(counterpartyId, reason));
 
 
-        private static CounterpartyInfo ToCounterpartyInfo(Counterparty counterparty, string markupFormula = null)
+        private static CounterpartySlimInfo ToCounterpartySlimInfo(Counterparty counterparty, string markupFormula = null)
             => new (counterparty.Id,
                 counterparty.Name,
                 counterparty.LegalAddress,
@@ -256,7 +260,7 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                 markupFormula);
 
 
-        private bool ConvertToDbStatus(ActivityStatus status) => status == ActivityStatus.Active;
+        private static bool ConvertToDbStatus(ActivityStatus status) => status == ActivityStatus.Active;
         
 
         private readonly EdoContext _context;

--- a/Api/AdministratorServices/CounterpartyManagementService.cs
+++ b/Api/AdministratorServices/CounterpartyManagementService.cs
@@ -54,7 +54,7 @@ namespace HappyTravel.Edo.Api.AdministratorServices
         }
 
 
-        public async Task<List<CounterpartySlimInfo>> Get()
+        public async Task<List<SlimCounterpartyInfo>> Get()
         {
             var counterparties = await (from cp in _context.Counterparties
                 join formula in _context.DisplayMarkupFormulas on new
@@ -248,7 +248,7 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                 new CounterpartyActivityStatusChangeEventData(counterpartyId, reason));
 
 
-        private static CounterpartySlimInfo ToCounterpartySlimInfo(Counterparty counterparty, string markupFormula = null)
+        private static SlimCounterpartyInfo ToCounterpartySlimInfo(Counterparty counterparty, string markupFormula = null)
             => new (counterparty.Id,
                 counterparty.Name,
                 counterparty.LegalAddress,

--- a/Api/AdministratorServices/CounterpartyManagementService.cs
+++ b/Api/AdministratorServices/CounterpartyManagementService.cs
@@ -47,7 +47,7 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                 select cp.ToCounterpartyInfo(c.Names, languageCode, null))
                     .SingleOrDefaultAsync();
 
-            if (counterpartyInfo.Equals(default))
+            if (counterpartyInfo.Id == 0)
                 return Result.Failure<CounterpartyInfo>("Could not find counterparty with specified id");
 
             return counterpartyInfo;
@@ -175,7 +175,7 @@ namespace HappyTravel.Edo.Api.AdministratorServices
             if (counterparty == null)
                 return Result.Failure<Counterparty>("Could not find counterparty with specified id");
 
-            return Result.Success(counterparty);
+            return counterparty;
         }
 
 

--- a/Api/AdministratorServices/ICounterpartyManagementService.cs
+++ b/Api/AdministratorServices/ICounterpartyManagementService.cs
@@ -10,9 +10,9 @@ namespace HappyTravel.Edo.Api.AdministratorServices
 {
     public interface ICounterpartyManagementService
     {
-        Task<Result<CounterpartyInfo>> Get(int counterpartyId);
+        Task<Result<CounterpartyInfo>> Get(int counterpartyId, string languageCode = LocalizationHelper.DefaultLanguageCode);
 
-        Task<List<CounterpartyInfo>> Get();
+        Task<List<CounterpartySlimInfo>> Get();
 
         Task<List<CounterpartyPrediction>> GetCounterpartiesPredictions(string query);
 

--- a/Api/AdministratorServices/ICounterpartyManagementService.cs
+++ b/Api/AdministratorServices/ICounterpartyManagementService.cs
@@ -12,7 +12,7 @@ namespace HappyTravel.Edo.Api.AdministratorServices
     {
         Task<Result<CounterpartyInfo>> Get(int counterpartyId, string languageCode = LocalizationHelper.DefaultLanguageCode);
 
-        Task<List<CounterpartySlimInfo>> Get();
+        Task<List<SlimCounterpartyInfo>> Get();
 
         Task<List<CounterpartyPrediction>> GetCounterpartiesPredictions(string query);
 

--- a/Api/Controllers/AdministratorControllers/CounterpartiesController.cs
+++ b/Api/Controllers/AdministratorControllers/CounterpartiesController.cs
@@ -56,7 +56,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         /// </summary>
         /// <returns></returns>
         [HttpGet]
-        [ProducesResponseType(typeof(List<CounterpartySlimInfo>), (int) HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(List<SlimCounterpartyInfo>), (int) HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.CounterpartyManagement)]
         public async Task<IActionResult> Get() => Ok(await _counterpartyManagementService.Get());

--- a/Api/Controllers/AdministratorControllers/CounterpartiesController.cs
+++ b/Api/Controllers/AdministratorControllers/CounterpartiesController.cs
@@ -38,7 +38,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         /// <param name="counterpartyId">Id of counterparty to get</param>
         /// <returns></returns>
         [HttpGet("{counterpartyId}")]
-        [ProducesResponseType(typeof(List<CounterpartyInfo>), (int) HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(CounterpartyInfo), (int) HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.CounterpartyManagement)]
         public async Task<IActionResult> Get(int counterpartyId)
@@ -56,7 +56,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         /// </summary>
         /// <returns></returns>
         [HttpGet]
-        [ProducesResponseType(typeof(List<CounterpartyInfo>), (int) HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(List<CounterpartySlimInfo>), (int) HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.CounterpartyManagement)]
         public async Task<IActionResult> Get() => Ok(await _counterpartyManagementService.Get());

--- a/Api/Extensions/CounterpartyInfoExtensions.cs
+++ b/Api/Extensions/CounterpartyInfoExtensions.cs
@@ -9,6 +9,7 @@ namespace HappyTravel.Edo.Api.Extensions
         public static CounterpartyInfo ToCounterpartyInfo(this Counterparty counterparty, string countryNames, string languageCode, string markupFormula = null)
             => new(counterparty.Id,
                 counterparty.Name,
+                counterparty.LegalAddress,
                 counterparty.Address,
                 counterparty.BillingEmail,
                 counterparty.City,

--- a/Api/Extensions/CounterpartyInfoExtensions.cs
+++ b/Api/Extensions/CounterpartyInfoExtensions.cs
@@ -1,0 +1,29 @@
+﻿using HappyTravel.Edo.Api.Infrastructure;
+using HappyTravel.Edo.Api.Models.Agents;
+using HappyTravel.Edo.Data.Agents;
+
+namespace HappyTravel.Edo.Api.Extensions
+{
+    public static class CounterpartyInfoExtensions
+    {
+        public static CounterpartyInfo ToCounterpartyInfo(this Counterparty counterparty, string countryNames, string languageCode, string markupFormula = null)
+            => new(counterparty.Id,
+                counterparty.Name,
+                counterparty.Address,
+                counterparty.BillingEmail,
+                counterparty.City,
+                counterparty.CountryCode,
+                LocalizationHelper.GetValueFromSerializedString(countryNames, languageCode),
+                counterparty.Fax,
+                counterparty.Phone,
+                counterparty.PostalCode,
+                counterparty.Website,
+                counterparty.VatNumber,
+                counterparty.PreferredPaymentMethod,
+                counterparty.IsContractUploaded,
+                counterparty.State,
+                counterparty.Verified,
+                counterparty.IsActive,
+                markupFormula);
+    }
+}

--- a/Api/Extensions/CounterpartyInfoExtensions.cs
+++ b/Api/Extensions/CounterpartyInfoExtensions.cs
@@ -7,24 +7,24 @@ namespace HappyTravel.Edo.Api.Extensions
     public static class CounterpartyInfoExtensions
     {
         public static CounterpartyInfo ToCounterpartyInfo(this Counterparty counterparty, string countryNames, string languageCode, string markupFormula = null)
-            => new(counterparty.Id,
-                counterparty.Name,
-                counterparty.LegalAddress,
-                counterparty.Address,
-                counterparty.BillingEmail,
-                counterparty.City,
-                counterparty.CountryCode,
-                LocalizationHelper.GetValueFromSerializedString(countryNames, languageCode),
-                counterparty.Fax,
-                counterparty.Phone,
-                counterparty.PostalCode,
-                counterparty.Website,
-                counterparty.VatNumber,
-                counterparty.PreferredPaymentMethod,
-                counterparty.IsContractUploaded,
-                counterparty.State,
-                counterparty.Verified,
-                counterparty.IsActive,
-                markupFormula);
+            => new (id: counterparty.Id,
+                name: counterparty.Name,
+                legalAddress: counterparty.LegalAddress,
+                address: counterparty.Address,
+                billingEmail: counterparty.BillingEmail,
+                city: counterparty.City,
+                countryCode: counterparty.CountryCode,
+                countryName: LocalizationHelper.GetValueFromSerializedString(countryNames, languageCode),
+                fax: counterparty.Fax,
+                phone: counterparty.Phone,
+                postalCode: counterparty.PostalCode,
+                website: counterparty.Website,
+                vatNumber: counterparty.VatNumber,
+                preferredPaymentMethod: counterparty.PreferredPaymentMethod,
+                isContractUploaded: counterparty.IsContractUploaded,
+                verificationState: counterparty.State,
+                verificationDate: counterparty.Verified,
+                isActive: counterparty.IsActive,
+                markupFormula: markupFormula);
     }
 }

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -2706,14 +2706,54 @@
                 Counterparty name.
             </summary>
         </member>
-        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyEditRequest.PreferredPaymentMethod">
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyEditRequest.Address">
             <summary>
-                Preferable way to do payments.
+                Counterparty address.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyEditRequest.CountryCode">
+            <summary>
+                Two-letter international country code.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyEditRequest.City">
+            <summary>
+                City name.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyEditRequest.Phone">
+            <summary>
+                Phone number. Only digits, length between 3 and 30.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyEditRequest.Fax">
+            <summary>
+                Fax number. Only digits, length between 3 and 30.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyEditRequest.PostalCode">
+            <summary>
+                Postal code.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyEditRequest.Website">
+            <summary>
+                Counterparty site url.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyEditRequest.BillingEmail">
+            <summary>
+            E-mail for billing operations
             </summary>
         </member>
         <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyEditRequest.VatNumber">
             <summary>
             Value added tax identification number
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyEditRequest.PreferredPaymentMethod">
+            <summary>
+                Preferable way to do payments.
             </summary>
         </member>
         <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyInfo.Id">

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -2731,6 +2731,56 @@
                 Agency address.
             </summary>
         </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyInfo.Address">
+            <summary>
+                Counterparty address.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyInfo.CountryCode">
+            <summary>
+                Two-letter international country code.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyInfo.CountryName">
+            <summary>
+            Country name.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyInfo.City">
+            <summary>
+                City name.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyInfo.Phone">
+            <summary>
+                Phone number. Only digits, length between 3 and 30.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyInfo.Fax">
+            <summary>
+                Fax number. Only digits, length between 3 and 30.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyInfo.PostalCode">
+            <summary>
+                Postal code.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyInfo.Website">
+            <summary>
+                Counterparty site url.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyInfo.BillingEmail">
+            <summary>
+            E-mail for billing operations
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyInfo.VatNumber">
+            <summary>
+            Value added tax identification number
+            </summary>
+        </member>
         <member name="P:HappyTravel.Edo.Api.Models.Agents.CounterpartyInfo.PreferredPaymentMethod">
             <summary>
                 Preferable way to do payments.
@@ -2857,6 +2907,51 @@
             </summary>
         </member>
         <member name="P:HappyTravel.Edo.Api.Models.Agents.SlimAgentInfo.IsActive">
+            <summary>
+            Activity state
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.SlimCounterpartyInfo.Id">
+            <summary>
+            Counterparty Id.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.SlimCounterpartyInfo.Name">
+            <summary>
+                Counterparty name.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.SlimCounterpartyInfo.LegalAddress">
+            <summary>
+                Agency address.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.SlimCounterpartyInfo.PreferredPaymentMethod">
+            <summary>
+                Preferable way to do payments.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.SlimCounterpartyInfo.IsContractUploaded">
+            <summary>
+            True if contract is loaded to counterparty
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.SlimCounterpartyInfo.VerificationState">
+            <summary>
+            Verification state of the counterparty
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.SlimCounterpartyInfo.MarkupFormula">
+            <summary>
+            Displayed markup formula
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.SlimCounterpartyInfo.VerificationDate">
+            <summary>
+            Counterparty verification date
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agents.SlimCounterpartyInfo.IsActive">
             <summary>
             Activity state
             </summary>

--- a/Api/Models/Agents/CounterpartyEditRequest.cs
+++ b/Api/Models/Agents/CounterpartyEditRequest.cs
@@ -7,11 +7,20 @@ namespace HappyTravel.Edo.Api.Models.Agents
     public readonly struct CounterpartyEditRequest
     {
         [JsonConstructor]
-        public CounterpartyEditRequest(string name, PaymentTypes preferredPaymentMethod, string vatNumber)
+        public CounterpartyEditRequest(string name, string address, string billingEmail, string city, string countryCode,
+            string fax, string phone, string postalCode, string website, string vatNumber, PaymentTypes preferredPaymentMethod)
         {
             Name = name;
-            PreferredPaymentMethod = preferredPaymentMethod;
+            Address = address;
+            BillingEmail = billingEmail;
+            City = city;
+            CountryCode = countryCode;
+            Fax = fax;
+            Phone = phone;
+            PostalCode = postalCode;
+            Website = website;
             VatNumber = vatNumber;
+            PreferredPaymentMethod = preferredPaymentMethod;
         }
 
 
@@ -22,14 +31,57 @@ namespace HappyTravel.Edo.Api.Models.Agents
         public string Name { get; }
 
         /// <summary>
-        ///     Preferable way to do payments.
+        ///     Counterparty address.
         /// </summary>
         [Required]
-        public PaymentTypes PreferredPaymentMethod { get; }
+        public string Address { get; }
+
+        /// <summary>
+        ///     Two-letter international country code.
+        /// </summary>
+        public string CountryCode { get; }
+
+        /// <summary>
+        ///     City name.
+        /// </summary>
+        [Required]
+        public string City { get; }
+
+        /// <summary>
+        ///     Phone number. Only digits, length between 3 and 30.
+        /// </summary>
+        [Required]
+        public string Phone { get; }
+
+        /// <summary>
+        ///     Fax number. Only digits, length between 3 and 30.
+        /// </summary>
+        public string Fax { get; }
+
+        /// <summary>
+        ///     Postal code.
+        /// </summary>
+        public string PostalCode { get; }
+
+        /// <summary>
+        ///     Counterparty site url.
+        /// </summary>
+        public string Website { get; }
+
+        /// <summary>
+        /// E-mail for billing operations
+        /// </summary>
+        public string BillingEmail { get; }
 
         /// <summary>
         /// Value added tax identification number
         /// </summary>
         public string VatNumber { get; }
+
+        /// <summary>
+        ///     Preferable way to do payments.
+        /// </summary>
+        [Required]
+        public PaymentTypes PreferredPaymentMethod { get; }
     }
 }

--- a/Api/Models/Agents/CounterpartyInfo.cs
+++ b/Api/Models/Agents/CounterpartyInfo.cs
@@ -8,13 +8,14 @@ namespace HappyTravel.Edo.Api.Models.Agents
     public readonly struct CounterpartyInfo
     {
         [JsonConstructor]
-        public CounterpartyInfo(int id, string name, string address, string billingEmail, string city, string countryCode, string countryName, 
+        public CounterpartyInfo(int id, string name, string legalAddress, string address, string billingEmail, string city, string countryCode, string countryName, 
             string fax, string phone, string postalCode, string website, string vatNumber, PaymentTypes preferredPaymentMethod,
             bool isContractUploaded, CounterpartyStates verificationState, DateTime? verificationDate, bool isActive,
             string markupFormula = null)
         {
             Id = id;
             Name = name;
+            LegalAddress = legalAddress;
             Address = address;
             BillingEmail = billingEmail;
             City = city;
@@ -43,6 +44,12 @@ namespace HappyTravel.Edo.Api.Models.Agents
         ///     Counterparty name.
         /// </summary>
         public string Name { get; }
+
+        /// <summary>
+        ///     Agency address.
+        /// </summary>
+        [Required]
+        public string LegalAddress { get; }
 
         /// <summary>
         ///     Counterparty address.

--- a/Api/Models/Agents/CounterpartyInfo.cs
+++ b/Api/Models/Agents/CounterpartyInfo.cs
@@ -8,13 +8,23 @@ namespace HappyTravel.Edo.Api.Models.Agents
     public readonly struct CounterpartyInfo
     {
         [JsonConstructor]
-        public CounterpartyInfo(int id, string name, string legalAddress, PaymentTypes preferredPaymentMethod,
+        public CounterpartyInfo(int id, string name, string address, string billingEmail, string city, string countryCode, string countryName, 
+            string fax, string phone, string postalCode, string website, string vatNumber, PaymentTypes preferredPaymentMethod,
             bool isContractUploaded, CounterpartyStates verificationState, DateTime? verificationDate, bool isActive,
             string markupFormula = null)
         {
             Id = id;
             Name = name;
-            LegalAddress = legalAddress;
+            Address = address;
+            BillingEmail = billingEmail;
+            City = city;
+            CountryCode = countryCode;
+            CountryName = countryName;
+            Fax = fax;
+            Phone = phone;
+            PostalCode = postalCode;
+            Website = website;
+            VatNumber = vatNumber;
             PreferredPaymentMethod = preferredPaymentMethod;
             IsContractUploaded = isContractUploaded;
             VerificationState = verificationState;
@@ -35,10 +45,57 @@ namespace HappyTravel.Edo.Api.Models.Agents
         public string Name { get; }
 
         /// <summary>
-        ///     Agency address.
+        ///     Counterparty address.
         /// </summary>
         [Required]
-        public string LegalAddress { get; }
+        public string Address { get; }
+
+        /// <summary>
+        ///     Two-letter international country code.
+        /// </summary>
+        public string CountryCode { get; }
+
+        /// <summary>
+        /// Country name.
+        /// </summary>
+        public string CountryName { get; }
+
+        /// <summary>
+        ///     City name.
+        /// </summary>
+        [Required]
+        public string City { get; }
+
+        /// <summary>
+        ///     Phone number. Only digits, length between 3 and 30.
+        /// </summary>
+        [Required]
+        public string Phone { get; }
+
+        /// <summary>
+        ///     Fax number. Only digits, length between 3 and 30.
+        /// </summary>
+        public string Fax { get; }
+
+        /// <summary>
+        ///     Postal code.
+        /// </summary>
+        public string PostalCode { get; }
+
+        /// <summary>
+        ///     Counterparty site url.
+        /// </summary>
+        public string Website { get; }
+
+        /// <summary>
+        /// E-mail for billing operations
+        /// </summary>
+        public string BillingEmail { get; }
+
+        /// <summary>
+        /// Value added tax identification number
+        /// </summary>
+        public string VatNumber { get; }
 
         /// <summary>
         ///     Preferable way to do payments.

--- a/Api/Models/Agents/CounterpartySlimInfo.cs
+++ b/Api/Models/Agents/CounterpartySlimInfo.cs
@@ -1,0 +1,74 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using HappyTravel.Edo.Common.Enums;
+using Newtonsoft.Json;
+
+namespace HappyTravel.Edo.Api.Models.Agents
+{
+    public readonly struct CounterpartySlimInfo
+    {
+        [JsonConstructor]
+        public CounterpartySlimInfo(int id, string name, string legalAddress, PaymentTypes preferredPaymentMethod,
+            bool isContractUploaded, CounterpartyStates verificationState, DateTime? verificationDate, bool isActive,
+            string markupFormula = null)
+        {
+            Id = id;
+            Name = name;
+            LegalAddress = legalAddress;
+            PreferredPaymentMethod = preferredPaymentMethod;
+            IsContractUploaded = isContractUploaded;
+            VerificationState = verificationState;
+            MarkupFormula = markupFormula;
+            VerificationDate = verificationDate;
+            IsActive = isActive;
+        }
+
+        /// <summary>
+        /// Counterparty Id.
+        /// </summary>
+        [Required]
+        public int Id { get; }
+
+        /// <summary>
+        ///     Counterparty name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        ///     Agency address.
+        /// </summary>
+        [Required]
+        public string LegalAddress { get; }
+
+        /// <summary>
+        ///     Preferable way to do payments.
+        /// </summary>
+        public PaymentTypes PreferredPaymentMethod { get; }
+
+        /// <summary>
+        /// True if contract is loaded to counterparty
+        /// </summary>
+        public bool IsContractUploaded { get; }
+
+        /// <summary>
+        /// Verification state of the counterparty
+        /// </summary>
+        public CounterpartyStates VerificationState { get; }
+
+
+        /// <summary>
+        /// Displayed markup formula
+        /// </summary>
+        public string MarkupFormula { get; }
+
+        /// <summary>
+        /// Counterparty verification date
+        /// </summary>
+        public DateTime? VerificationDate { get; }
+
+        /// <summary>
+        /// Activity state
+        /// </summary>
+        public bool IsActive { get; }
+    }
+}

--- a/Api/Models/Agents/SlimCounterpartyInfo.cs
+++ b/Api/Models/Agents/SlimCounterpartyInfo.cs
@@ -5,10 +5,10 @@ using Newtonsoft.Json;
 
 namespace HappyTravel.Edo.Api.Models.Agents
 {
-    public readonly struct CounterpartySlimInfo
+    public readonly struct SlimCounterpartyInfo
     {
         [JsonConstructor]
-        public CounterpartySlimInfo(int id, string name, string legalAddress, PaymentTypes preferredPaymentMethod,
+        public SlimCounterpartyInfo(int id, string name, string legalAddress, PaymentTypes preferredPaymentMethod,
             bool isContractUploaded, CounterpartyStates verificationState, DateTime? verificationDate, bool isActive,
             string markupFormula = null)
         {

--- a/Api/Models/Agents/SlimCounterpartyInfo.cs
+++ b/Api/Models/Agents/SlimCounterpartyInfo.cs
@@ -55,7 +55,6 @@ namespace HappyTravel.Edo.Api.Models.Agents
         /// </summary>
         public CounterpartyStates VerificationState { get; }
 
-
         /// <summary>
         /// Displayed markup formula
         /// </summary>

--- a/Api/Services/Agents/AgentRegistrationService.cs
+++ b/Api/Services/Agents/AgentRegistrationService.cs
@@ -56,20 +56,20 @@ namespace HappyTravel.Edo.Api.Services.Agents
             bool IsIdentityPresent() => !string.IsNullOrWhiteSpace(externalIdentity);
 
 
-            Task<Result<CounterpartyInfo>> CreateCounterparty() 
+            Task<Result<SlimCounterpartyInfo>> CreateCounterparty() 
                 => _counterpartyService.Add(counterpartyData);
 
 
-            async Task<Result<(CounterpartyInfo, Agent)>> CreateAgent(CounterpartyInfo counterparty)
+            async Task<Result<(SlimCounterpartyInfo, Agent)>> CreateAgent(SlimCounterpartyInfo counterparty)
             {
                 var (_, isFailure, agent, error) = await _agentService.Add(agentData, externalIdentity, email);
                 return isFailure
-                    ? Result.Failure<(CounterpartyInfo, Agent)>(error)
+                    ? Result.Failure<(SlimCounterpartyInfo, Agent)>(error)
                     : Result.Success((counterparty1: counterparty, agent));
             }
 
 
-            async Task AddMasterAgentAgencyRelation((CounterpartyInfo counterparty, Agent agent) counterpartyAgentInfo)
+            async Task AddMasterAgentAgencyRelation((SlimCounterpartyInfo counterparty, Agent agent) counterpartyAgentInfo)
             {
                 var (counterparty, agent) = counterpartyAgentInfo;
                 var rootAgency = await _counterpartyService.GetRootAgency(counterparty.Id);
@@ -85,7 +85,7 @@ namespace HappyTravel.Edo.Api.Services.Agents
             }
 
 
-            async Task<Result> SendRegistrationMailToAdmins(CounterpartyInfo counterpartyInfo)
+            async Task<Result> SendRegistrationMailToAdmins(SlimCounterpartyInfo counterpartyInfo)
             {
                 var agent = $"{agentData.Title} {agentData.FirstName} {agentData.LastName}";
                 if (!string.IsNullOrWhiteSpace(agentData.Position))
@@ -119,7 +119,7 @@ namespace HappyTravel.Edo.Api.Services.Agents
             }
 
 
-            Result<CounterpartyInfo> LogSuccess((CounterpartyInfo, Agent) registrationData)
+            Result<SlimCounterpartyInfo> LogSuccess((SlimCounterpartyInfo, Agent) registrationData)
             {
                 var (counterparty, agent) = registrationData;
                 _logger.LogAgentRegistrationSuccess(agent.Email);

--- a/Api/Services/Agents/CounterpartyService.cs
+++ b/Api/Services/Agents/CounterpartyService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
@@ -25,7 +24,7 @@ namespace HappyTravel.Edo.Api.Services.Agents
         }
 
 
-        public async Task<Result<CounterpartyInfo>> Add(CounterpartyCreateRequest request)
+        public async Task<Result<SlimCounterpartyInfo>> Add(CounterpartyCreateRequest request)
         {
             var registrationAgencyInfo = request.RootAgencyInfo.ToRegistrationAgencyInfo(request.CounterpartyInfo.Name);
             return await Validate()
@@ -52,6 +51,15 @@ namespace HappyTravel.Edo.Api.Services.Agents
                     PreferredPaymentMethod = request.CounterpartyInfo.PreferredPaymentMethod,
                     State = CounterpartyStates.PendingVerification,
                     LegalAddress = request.CounterpartyInfo.LegalAddress,
+                    Address = request.RootAgencyInfo.Address,
+                    BillingEmail = request.RootAgencyInfo.BillingEmail,
+                    City = request.RootAgencyInfo.City,
+                    CountryCode = request.RootAgencyInfo.CountryCode,
+                    Fax = request.RootAgencyInfo.Fax,
+                    Phone = request.RootAgencyInfo.Phone,
+                    PostalCode = request.RootAgencyInfo.PostalCode,
+                    Website = request.RootAgencyInfo.Website,
+                    VatNumber = request.RootAgencyInfo.VatNumber,
                     Created = now,
                     Updated = now
                 };
@@ -140,7 +148,7 @@ namespace HappyTravel.Edo.Api.Services.Agents
                 .SingleAsync(a => a.CounterpartyId == counterpartyId && a.ParentId == null);
 
 
-        public async Task<Result<CounterpartyInfo>> Get(int counterpartyId)
+        public async Task<Result<SlimCounterpartyInfo>> Get(int counterpartyId)
         {
             return await GetCounterpartyInfo(counterpartyId);
         }
@@ -152,9 +160,9 @@ namespace HappyTravel.Edo.Api.Services.Agents
                 .Map(cp => cp.ContractKind.Value);
 
 
-        private Task<Result<CounterpartyInfo>> GetCounterpartyInfo(int counterpartyId)
+        private Task<Result<SlimCounterpartyInfo>> GetCounterpartyInfo(int counterpartyId)
             => GetCounterpartyRecord(counterpartyId)
-                .Map(c => new CounterpartyInfo(
+                .Map(c => new SlimCounterpartyInfo(
                     c.Id,
                     c.Name,
                     c.LegalAddress,

--- a/Api/Services/Agents/ICounterpartyService.cs
+++ b/Api/Services/Agents/ICounterpartyService.cs
@@ -1,6 +1,5 @@
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
-using HappyTravel.Edo.Api.Infrastructure;
 using HappyTravel.Edo.Api.Models.Agents;
 using HappyTravel.Edo.Data.Agents;
 
@@ -8,9 +7,9 @@ namespace HappyTravel.Edo.Api.Services.Agents
 {
     public interface ICounterpartyService
     {
-        Task<Result<CounterpartyInfo>> Add(CounterpartyCreateRequest counterparty);
+        Task<Result<SlimCounterpartyInfo>> Add(CounterpartyCreateRequest counterparty);
 
-        Task<Result<CounterpartyInfo>> Get(int counterpartyId);
+        Task<Result<SlimCounterpartyInfo>> Get(int counterpartyId);
 
         Task<Result<CounterpartyContractKind>> GetContractKind(int counterpartyId);
 

--- a/HappyTravel.Edo.Data/Agents/Counterparty.cs
+++ b/HappyTravel.Edo.Data/Agents/Counterparty.cs
@@ -17,5 +17,14 @@ namespace HappyTravel.Edo.Data.Agents
         public bool IsActive { get; set; }
         public bool IsContractUploaded { get; set; }
         public CounterpartyContractKind? ContractKind { get; set; }
+        public string Address { get; set; }
+        public string CountryCode { get; set; }
+        public string City { get; set; }
+        public string Phone { get; set; }
+        public string Fax { get; set; }
+        public string PostalCode { get; set; }
+        public string Website { get; set; }
+        public string VatNumber { get; set; }
+        public string BillingEmail { get; set; }
     }
 }

--- a/HappyTravel.Edo.Data/EdoContext.cs
+++ b/HappyTravel.Edo.Data/EdoContext.cs
@@ -469,11 +469,13 @@ namespace HappyTravel.Edo.Data
                 counterparty.Property(c => c.Id).ValueGeneratedOnAdd();
                 counterparty.Property(c => c.Name).IsRequired();
                 counterparty.Property(c => c.LegalAddress).IsRequired();
+                counterparty.Property(c => c.Address).IsRequired();
+                counterparty.Property(c => c.City).IsRequired();
+                counterparty.Property(c => c.CountryCode).IsRequired();
+                counterparty.Property(c => c.Phone).IsRequired();
                 counterparty.Property(c => c.PreferredPaymentMethod).IsRequired();
                 counterparty.Property(c => c.State).IsRequired();
-                counterparty.Property(c => c.IsActive)
-                    .IsRequired()
-                    .HasDefaultValue(true);
+                counterparty.Property(c => c.IsActive).IsRequired().HasDefaultValue(true);
             });
         }
 

--- a/HappyTravel.Edo.Data/Migrations/20210803072255_ModifyCounterpartiesAddContacts.Designer.cs
+++ b/HappyTravel.Edo.Data/Migrations/20210803072255_ModifyCounterpartiesAddContacts.Designer.cs
@@ -7,15 +7,17 @@ using HappyTravel.Edo.Data.Agents;
 using HappyTravel.Edo.Data.Bookings;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace HappyTravel.Edo.Data.Migrations
 {
     [DbContext(typeof(EdoContext))]
-    partial class EdoContextModelSnapshot : ModelSnapshot
+    [Migration("20210803072255_ModifyCounterpartiesAddContacts")]
+    partial class ModifyCounterpartiesAddContacts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HappyTravel.Edo.Data/Migrations/20210803072255_ModifyCounterpartiesAddContacts.cs
+++ b/HappyTravel.Edo.Data/Migrations/20210803072255_ModifyCounterpartiesAddContacts.cs
@@ -64,12 +64,12 @@ namespace HappyTravel.Edo.Data.Migrations
                 type: "text",
                 nullable: true);
 
-            migrationBuilder.Sql("UPDATE \"Counterparties\" " +
-                "SET \"Address\" = \"Agencies.Address\", \"BillingEmail\" = \"Agencies.BillingEmail\", \"City\" = \"Agencies.City\", " +
-                    "\"CountryCode\" = \"Agencies.CountryCode\", \"Fax\" = \"Agencies.Fax\", \"Phone\" = \"Agencies.Phone\", " +
-                    "\"PostalCode\" = \"Agencies.PostalCode\", \"Website\" = \"Agencies.Website\", \"VatNumber\" = \"Agencies.VatNumber\" " +
-                "FROM \"Agencies\" " +
-                "WHERE \"Agencies.CounterpartyId\" = \"Counterparties.Id\" AND \"Agencies.ParentId\" = NULL;");
+            migrationBuilder.Sql("UPDATE \"Counterparties\" c " +
+                "SET \"Address\" = a.\"Address\", \"BillingEmail\" = a.\"BillingEmail\", \"City\" = a.\"City\", " +
+                    "\"CountryCode\" = a.\"CountryCode\", \"Fax\" = a.\"Fax\", \"Phone\" = a.\"Phone\", " +
+                    "\"PostalCode\" = a.\"PostalCode\", \"Website\" = a.\"Website\", \"VatNumber\" = a.\"VatNumber\" " +
+                "FROM \"Agencies\" a " +
+                "WHERE a.\"CounterpartyId\" = c.\"Id\" AND a.\"ParentId\" = NULL;");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/HappyTravel.Edo.Data/Migrations/20210803072255_ModifyCounterpartiesAddContacts.cs
+++ b/HappyTravel.Edo.Data/Migrations/20210803072255_ModifyCounterpartiesAddContacts.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace HappyTravel.Edo.Data.Migrations
+{
+    public partial class ModifyCounterpartiesAddContacts : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Address",
+                table: "Counterparties",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "BillingEmail",
+                table: "Counterparties",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "City",
+                table: "Counterparties",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CountryCode",
+                table: "Counterparties",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Fax",
+                table: "Counterparties",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Phone",
+                table: "Counterparties",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "PostalCode",
+                table: "Counterparties",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "VatNumber",
+                table: "Counterparties",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Website",
+                table: "Counterparties",
+                type: "text",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Address",
+                table: "Counterparties");
+
+            migrationBuilder.DropColumn(
+                name: "BillingEmail",
+                table: "Counterparties");
+
+            migrationBuilder.DropColumn(
+                name: "City",
+                table: "Counterparties");
+
+            migrationBuilder.DropColumn(
+                name: "CountryCode",
+                table: "Counterparties");
+
+            migrationBuilder.DropColumn(
+                name: "Fax",
+                table: "Counterparties");
+
+            migrationBuilder.DropColumn(
+                name: "Phone",
+                table: "Counterparties");
+
+            migrationBuilder.DropColumn(
+                name: "PostalCode",
+                table: "Counterparties");
+
+            migrationBuilder.DropColumn(
+                name: "VatNumber",
+                table: "Counterparties");
+
+            migrationBuilder.DropColumn(
+                name: "Website",
+                table: "Counterparties");
+        }
+    }
+}

--- a/HappyTravel.Edo.Data/Migrations/20210803072255_ModifyCounterpartiesAddContacts.cs
+++ b/HappyTravel.Edo.Data/Migrations/20210803072255_ModifyCounterpartiesAddContacts.cs
@@ -63,6 +63,13 @@ namespace HappyTravel.Edo.Data.Migrations
                 table: "Counterparties",
                 type: "text",
                 nullable: true);
+
+            migrationBuilder.Sql("UPDATE \"Counterparties\" " +
+                "SET \"Address\" = \"Agencies.Address\", \"BillingEmail\" = \"Agencies.BillingEmail\", \"City\" = \"Agencies.City\", " +
+                    "\"CountryCode\" = \"Agencies.CountryCode\", \"Fax\" = \"Agencies.Fax\", \"Phone\" = \"Agencies.Phone\", " +
+                    "\"PostalCode\" = \"Agencies.PostalCode\", \"Website\" = \"Agencies.Website\", \"VatNumber\" = \"Agencies.VatNumber\" " +
+                "FROM \"Agencies\" " +
+                "WHERE \"Agencies.CounterpartyId\" = \"Counterparties.Id\" AND \"Agencies.ParentId\" = NULL;");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/CounterpartyManagementServiceTests/CounterpartyManagementTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/CounterpartyManagementServiceTests/CounterpartyManagementTests.cs
@@ -75,7 +75,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices.CounterpartyMana
                 address: "New address",
                 billingEmail: "new_test@test.org",
                 city: "new city",
-                countryCode: "RU",
+                countryCode: "AF",
                 fax: "+7 111 2222222",
                 phone: "+7 111 3333333",
                 postalCode: "345100",

--- a/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/CounterpartyManagementServiceTests/CounterpartyManagementTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/CounterpartyManagementServiceTests/CounterpartyManagementTests.cs
@@ -72,8 +72,16 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices.CounterpartyMana
         {
             var counterpartyToUpdate = new CounterpartyEditRequest(
                 name: "RenamedName",
-                preferredPaymentMethod: PaymentTypes.Offline,
-                vatNumber: "changed vatNumber"
+                address: "New address",
+                billingEmail: "new_test@test.org",
+                city: "new city",
+                countryCode: "RU",
+                fax: "+7 111 2222222",
+                phone: "+7 111 3333333",
+                postalCode: "345100",
+                website: "www.testsite.org",
+                vatNumber: "changed vatNumber",
+                preferredPaymentMethod: PaymentTypes.Offline
             );
 
             var (_, isFailure, counterparty, error) = await _counterpartyManagementService.Update(counterpartyToUpdate, 1);

--- a/HappyTravel.Edo.UnitTests/Utility/AdministratorServicesMockCreationHelper.cs
+++ b/HappyTravel.Edo.UnitTests/Utility/AdministratorServicesMockCreationHelper.cs
@@ -227,35 +227,55 @@ namespace HappyTravel.Edo.UnitTests.Utility
                 Id = 1,
                 Name = "Test",
                 IsActive = true,
-                State = CounterpartyStates.PendingVerification
+                State = CounterpartyStates.PendingVerification,
+                Address = "Test address",
+                City = "Test city",
+                CountryCode = "AF",
+                Phone = "+7 111 1111111"
             },
             new Counterparty
             {
                 Id = 2,
                 Name = "Test1",
                 IsActive = false,
-                State = CounterpartyStates.PendingVerification
+                State = CounterpartyStates.PendingVerification,
+                Address = "Test address 2",
+                City = "Test city 2",
+                CountryCode = "AF",
+                Phone = "+7 222 2222222"
             },
             new Counterparty
             {
                 Id = 3,
                 Name = "Test",
                 IsActive = true,
-                State = CounterpartyStates.ReadOnly
+                State = CounterpartyStates.ReadOnly,
+                Address = "Test address 3",
+                City = "Test city 3",
+                CountryCode = "AF",
+                Phone = "+7 333 3333333"
             },
             new Counterparty
             {
                 Id = 14,
                 Name = "CounterpartyWithBillingEmail",
                 State = CounterpartyStates.FullAccess,
-                IsActive = true
+                IsActive = true,
+                Address = "Test address 4",
+                City = "Test city 4",
+                CountryCode = "AF",
+                Phone = "+7 444 4444444"
             },
             new Counterparty
             {
                 Id = 15,
                 Name = "CounterpartyWithoutBillingEmail",
                 State = CounterpartyStates.FullAccess,
-                IsActive = true
+                IsActive = true,
+                Address = "Test address 5",
+                City = "Test city 5",
+                CountryCode = "AF",
+                Phone = "+7 555 5555555"
             }
         };
 


### PR DESCRIPTION
Added contact info to Counterparty. Added migration to database. Added filling in the contact details of the counterparty from the main agency during creation. Added the ability to edit the contact details of the counterparty before completing its verification. Fixed unit tests.