### PR TITLE
Add sources data to full booking report

### DIFF
--- a/Api/Models/Reports/DirectConnectivityReports/FullBookingsReportData.cs
+++ b/Api/Models/Reports/DirectConnectivityReports/FullBookingsReportData.cs
@@ -14,6 +14,10 @@ namespace HappyTravel.Edo.Api.Models.Reports.DirectConnectivityReports
         public string AccommodationName { get; init; }
         public string ConfirmationNumber { get; init; }
         public string AgencyName { get; init; }
+        public string AgentName { get; init; }
+        public string AgencyCountry { get; init; }
+        public string AgencyCity { get; init; }
+        public string AgencyRegion { get; init; }
         public PaymentTypes PaymentMethod { get; init; }
         public string GuestName { get; init; }
         public DateTime Created { get; init; }

--- a/Api/Models/Reports/DirectConnectivityReports/FullBookingsReportRow.cs
+++ b/Api/Models/Reports/DirectConnectivityReports/FullBookingsReportRow.cs
@@ -9,7 +9,11 @@ namespace HappyTravel.Edo.Api.Models.Reports.DirectConnectivityReports
         public string AccommodationName { get; init; }
         public string ConfirmationNumber { get; init; }
         public string RoomsConfirmationNumbers { get; init; }
+        public string AgentName { get; init; }
         public string AgencyName { get; init; }
+        public string AgencyCity { get; init; }
+        public string AgencyCountry { get; init; }
+        public string AgencyRegion { get; init; }
         public string PaymentMethod { get; init; }
         public string GuestName { get; init; }
         public string Created { get; init; }

--- a/Api/Services/Reports/Converters/FullBookingsReportDataConverter.cs
+++ b/Api/Services/Reports/Converters/FullBookingsReportDataConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Text.Json;
 using HappyTravel.Edo.Api.Models.Reports.DirectConnectivityReports;
 using HappyTravel.DataFormatters;
 using HappyTravel.Edo.Api.Services.Reports.Helpers;
@@ -15,6 +16,10 @@ namespace HappyTravel.Edo.Api.Services.Reports.Converters
                 ReferenceCode = data.ReferenceCode,
                 InvoiceNumber = data.InvoiceNumber,
                 AgencyName = data.AgencyName,
+                AgencyCity = data.AgencyCity,
+                AgencyCountry = GetJsonProperty(data.AgencyCountry, "en"),
+                AgencyRegion = GetJsonProperty(data.AgencyRegion, "en"),
+                AgentName = data.AgentName,
                 PaymentMethod = EnumFormatters.FromDescription(data.PaymentMethod),
                 GuestName = data.GuestName,
                 AccommodationName = data.AccommodationName,
@@ -39,5 +44,14 @@ namespace HappyTravel.Edo.Api.Services.Reports.Converters
                         .Select(p => p.Percentage)
                         .FirstOrDefault()
             };
+
+
+        private string GetJsonProperty(string json, string property)
+        {
+            return JsonDocument.Parse(json)
+                .RootElement
+                .GetProperty(property)
+                .GetString();
+        }
     }
 }

--- a/Api/Services/Reports/RecordManagers/FullBookingsRecordManager.cs
+++ b/Api/Services/Reports/RecordManagers/FullBookingsRecordManager.cs
@@ -23,6 +23,9 @@ namespace HappyTravel.Edo.Api.Services.Reports.RecordManagers
                     join invoice in _context.Invoices on booking.ReferenceCode equals invoice.ParentReferenceCode
                     join order in _context.SupplierOrders on booking.ReferenceCode equals order.ReferenceCode
                     join agency in _context.Agencies on booking.AgencyId equals agency.Id
+                    join agent in _context.Agents on booking.AgentId equals agent.Id
+                    join country in _context.Countries on agency.CountryCode equals country.Code
+                    join region in _context.Regions on country.RegionId equals region.Id
                     let cancellationDate = _context.BookingStatusHistory
                         .Where(c => c.BookingId == booking.Id && c.Status == BookingStatuses.Cancelled)
                         .Select(c => c.CreatedAt)
@@ -36,6 +39,10 @@ namespace HappyTravel.Edo.Api.Services.Reports.RecordManagers
                         ReferenceCode = booking.ReferenceCode,
                         InvoiceNumber = invoice.Number,
                         AgencyName = agency.Name,
+                        AgencyCity = agency.City,
+                        AgencyCountry = country.Names,
+                        AgentName = $"{agent.FirstName} {agent.LastName}",
+                        AgencyRegion = region.Names,
                         PaymentMethod = booking.PaymentType,
                         AccommodationName = booking.AccommodationName,
                         ConfirmationNumber = booking.SupplierReferenceCode,


### PR DESCRIPTION
Per https://github.com/happy-travel/agent-app-project/issues/409

> Bookings by Markets: Region/Country/City/Accommodation/Agent
> And from which source (up to agent level)
> Example: Sodis/Moscow/Russia/CIS; Private Travel UK/London/UK/Europe
> Example: which agents booked with us Mandarion Oriental Dubai in 2020 and breakdown by source of the business: EUR agents, > RUS agents, etc. Up to booking level and a total amount booked on each sub-level as well as grand total.