### PR TITLE
Changed double flow to distributed flow

### DIFF
--- a/Api/Services/Accommodations/Bookings/Management/BookingStatusRefreshService.cs
+++ b/Api/Services/Accommodations/Bookings/Management/BookingStatusRefreshService.cs
@@ -19,12 +19,9 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Management
 {
     public class BookingStatusRefreshService : IBookingStatusRefreshService
     {
-        public BookingStatusRefreshService(
-            IDoubleFlow flow,
-            IDateTimeProvider dateTimeProvider,
-            ISupplierBookingManagementService supplierBookingManagement,
-            EdoContext context,
-            IOptions<BookingOptions> bookingOptions)
+        public BookingStatusRefreshService(IDistributedFlow flow,
+            IDateTimeProvider dateTimeProvider, ISupplierBookingManagementService supplierBookingManagement,
+            EdoContext context, IOptions<BookingOptions> bookingOptions)
         {
             _flow = flow;
             _dateTimeProvider = dateTimeProvider;
@@ -154,13 +151,14 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Management
             }
 
 
-            Task<Result> RefreshBookingStatus() => _supplierBookingManagement.RefreshStatus(booking, apiCaller, BookingChangeEvents.Refresh);
+            Task<Result> RefreshBookingStatus() 
+                => _supplierBookingManagement.RefreshStatus(booking, apiCaller, BookingChangeEvents.Refresh);
         }
 
 
         private async Task<List<BookingStatusRefreshState>> GetStates()
         {
-            return await _flow.GetAsync<List<BookingStatusRefreshState>>(Key, Expiration)
+            return await _flow.GetAsync<List<BookingStatusRefreshState>>(Key)
                 ?? new List<BookingStatusRefreshState>();
         }
 
@@ -232,7 +230,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.Management
 
         private static readonly TimeSpan Expiration = TimeSpan.FromDays(3);
 
-        private readonly IDoubleFlow _flow;
+        private readonly IDistributedFlow _flow;
         private readonly IDateTimeProvider _dateTimeProvider;
         private readonly ISupplierBookingManagementService _supplierBookingManagement;
         private readonly EdoContext _context;

--- a/Api/Services/Accommodations/Bookings/ResponseProcessing/BookingResponseProcessor.cs
+++ b/Api/Services/Accommodations/Bookings/ResponseProcessing/BookingResponseProcessor.cs
@@ -84,7 +84,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.ResponseProcessin
 
         private async Task ProcessBookingNotFound(Data.Bookings.Booking booking, Booking bookingResponse, BookingChangeEvents eventType)
         {
-            if (_dateTimeProvider.UtcNow() < booking.Created + BookingCheckTimeout)
+            // If booking was confirmed or
+            if (_dateTimeProvider.UtcNow() < booking.Created + BookingCheckTimeout && booking.Status != BookingStatuses.Confirmed)
             {
                 _logger.LogBookingResponseProcessSuccess(bookingResponse.ReferenceCode, $"Has not been processed due to '{BookingStatusCodes.NotFound}' status.");
             }


### PR DESCRIPTION
To fix the error:
https://sentry1.happytravel.com/organizations/happytravel/issues/2528/events/e7637bb715fe453b92f453b4d8dc61e1/?project=45

And it looks like distributed flow suits better for saving such instance-independent values