### PR TITLE
Fixed credit card activation date

### DIFF
--- a/Api/Services/Accommodations/Bookings/BookingExecution/BookingRequestExecutor.cs
+++ b/Api/Services/Accommodations/Bookings/BookingExecution/BookingRequestExecutor.cs
@@ -163,7 +163,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Bookings.BookingExecution
             
             var activationDate = availabilityInfo.RoomContractSet.IsAdvancePurchaseRate
                 ? _dateTimeProvider.UtcNow()
-                : availabilityInfo.CheckOutDate;
+                : availabilityInfo.CheckInDate;
 
             var dueDate = availabilityInfo.RoomContractSet.IsAdvancePurchaseRate
                 ? availabilityInfo.CheckOutDate


### PR DESCRIPTION
Jumeirah prefers VCC to be activated as follows:
•	For bookings with Flexible cancellation policy – VCC should be activated on **arrival date** and remain active for 30 days after checkout.
•	For bookings with Non-Refundable cancellation policy such as Advance Purchase Rate – VCC should be activated on the booking date
