### PR TITLE
Feature/724 agency verification

### DIFF
--- a/Api/AdministratorServices/AgencyVerificationService.cs
+++ b/Api/AdministratorServices/AgencyVerificationService.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions;
+using HappyTravel.DataFormatters;
+using HappyTravel.Edo.Api.Infrastructure;
+using HappyTravel.Edo.Api.Infrastructure.FunctionalExtensions;
+using HappyTravel.Edo.Api.Infrastructure.Options;
+using HappyTravel.Edo.Api.Models.Agents;
+using HappyTravel.Edo.Api.Models.Mailing;
+using HappyTravel.Edo.Api.Models.Management.AuditEvents;
+using HappyTravel.Edo.Api.NotificationCenter.Services;
+using HappyTravel.Edo.Api.Services.Management;
+using HappyTravel.Edo.Api.Services.Payments.Accounts;
+using HappyTravel.Edo.Common.Enums;
+using HappyTravel.Edo.Data;
+using HappyTravel.Edo.Data.Agents;
+using HappyTravel.Edo.Notifications.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace HappyTravel.Edo.Api.AdministratorServices
+{
+    public class AgencyVerificationService : IAgencyVerificationService
+    {
+        public AgencyVerificationService(EdoContext context, IAccountManagementService accountManagementService,
+            IManagementAuditService managementAuditService, INotificationService notificationService,
+            IOptions<CounterpartyManagementMailingOptions> mailingOptions, IDateTimeProvider dateTimeProvider, Services.Agents.IAgentService agentService)
+        {
+            _context = context;
+            _accountManagementService = accountManagementService;
+            _managementAuditService = managementAuditService;
+            _notificationService = notificationService;
+            _mailingOptions = mailingOptions.Value;
+            _dateTimeProvider = dateTimeProvider;
+            _agentService = agentService;
+        }
+
+
+        public async Task<Result> VerifyAsFullyAccessed(int agencyId, CounterpartyContractKind contractKind, string verificationReason)
+        {
+            return await GetAgency(agencyId)
+                .Ensure(a => a.ParentId is null, "Verification is only available for root agencies")
+                .Ensure(a => a.VerificationState == CounterpartyStates.ReadOnly,
+                    "Verification as fully accessed is only available for agencies that were verified as read-only earlier")
+                .Ensure(IsContractTypeValid, "Invalid contract type")
+                .Tap(c => SetVerificationState(c, CounterpartyStates.FullAccess, verificationReason))
+                .Tap(SetContractType)
+                .Tap(() => WriteVerificationToAuditLog(agencyId, verificationReason, CounterpartyStates.FullAccess));
+            
+            
+            bool IsContractTypeValid(Agency _) 
+                => !contractKind.Equals(default(CounterpartyContractKind));
+            
+            
+            async Task SetContractType(Agency agency)
+            {
+                agency.ContractKind = contractKind;
+                await _context.SaveChangesAsync();
+            }
+        }
+
+
+        public Task<Result> VerifyAsReadOnly(int agencyId, string verificationReason)
+        {
+            return GetAgency(agencyId)
+                .Ensure(a => a.ParentId is null, "Verification is only available for root agencies")
+                .Ensure(a => a.VerificationState == CounterpartyStates.PendingVerification,
+                    "Verification as read-only is only available for agencies that are in pending verification step")
+                .BindWithTransaction(_context, agency => SetReadOnlyVerificationState(agency)
+                    .Bind(CreateAccountsForAgencies))
+                .Tap(() => WriteVerificationToAuditLog(agencyId, verificationReason, CounterpartyStates.ReadOnly));
+
+
+            async Task<Result<Agency>> SetReadOnlyVerificationState(Agency agency)
+            {
+                await SetVerificationState(agency, CounterpartyStates.ReadOnly, verificationReason);
+                return agency;
+            }
+
+
+            async Task<Result> CreateAccountsForAgencies(Agency agency)
+            {
+                var (_, isFailure) = await _accountManagementService.CreateForAgency(agency, agency.PreferredCurrency);
+                if (isFailure)
+                    return Result.Failure("Error while creating an account for agency");
+                
+                var childAgencies = await _context.Agencies.Where(a => a.Ancestors.Contains(agencyId)).ToListAsync();
+
+                foreach (var childAgency in childAgencies)
+                {
+                    var (_, isChildAgencyFailure) = await _accountManagementService.CreateForAgency(childAgency, childAgency.PreferredCurrency);
+                    if (isChildAgencyFailure)
+                        return Result.Failure("Error while creating accounts for child agencies");
+                }
+
+                return Result.Success();
+            }
+        }
+
+
+        public async Task<Result> DeclineVerification(int agencyId, string verificationReason)
+        {
+            return await GetAgency(agencyId)
+                .Ensure(a => a.ParentId is null, "Verification is only available for root agencies")
+                .Ensure(a => a.VerificationState == CounterpartyStates.PendingVerification,
+                    "Verification failure is only available for agencies that are in a pending state")
+                .Tap(a => SetVerificationState(a, CounterpartyStates.DeclinedVerification, verificationReason))
+                .Tap(() => WriteVerificationToAuditLog(agencyId, verificationReason, CounterpartyStates.DeclinedVerification));
+        }
+
+
+        private async Task SetVerificationState(Agency agency, CounterpartyStates state, string verificationReason)
+        {
+            var now = _dateTimeProvider.UtcNow();
+            string reason;
+            if (string.IsNullOrEmpty(agency.VerificationReason))
+                reason = verificationReason;
+            else
+                reason = agency.VerificationReason + Environment.NewLine + verificationReason;
+
+            agency.VerificationState = state;
+            agency.VerificationReason = reason;
+            agency.Verified = now;
+            agency.Modified = now;
+            _context.Update(agency);
+            await _context.SaveChangesAsync();
+
+            await SendNotificationToMaster();
+
+
+            async Task<Result> SendNotificationToMaster()
+            {
+                var (_, isFailure, master, error) = await _agentService.GetMasterAgent(agency.Id);
+                if (isFailure)
+                    return Result.Failure(error);
+
+                var messageData = new CounterpartyVerificationStateChangedData
+                {
+                    AgentName = $"{master.FirstName} {master.LastName}",
+                    CounterpartyName = agency.Name,
+                    State = EnumFormatters.FromDescription(state),
+                };
+
+                return await _notificationService.Send(agent: new SlimAgentContext(master.Id, agency.Id),
+                    messageData: messageData,
+                    notificationType: NotificationTypes.CounterpartyVerificationChanged,
+                    email: master.Email,
+                    templateId: _mailingOptions.CounterpartyVerificationChangedTemplateId);
+            }
+        }
+
+
+        private Task WriteVerificationToAuditLog(int agencyId, string verificationReason, CounterpartyStates verificationState)
+            => _managementAuditService.Write(ManagementEventType.AgencyVerification,
+                new AgencyVerifiedEventData(agencyId, verificationReason, verificationState));
+
+
+        // This method is the same with AdminAgencyManagementService.GetAgency,
+        // because administrator services in the future will be replaced to another application
+        private async Task<Result<Agency>> GetAgency(int agencyId)
+        {
+            var agency = await _context.Agencies.SingleOrDefaultAsync(c => c.Id == agencyId);
+
+            if (agency == null)
+                return Result.Failure<Agency>("Could not find agency with specified id");
+
+            return Result.Success(agency);
+        }
+
+
+        private readonly EdoContext _context;
+        private readonly IAccountManagementService _accountManagementService;
+        private readonly IManagementAuditService _managementAuditService;
+        private readonly INotificationService _notificationService;
+        private readonly CounterpartyManagementMailingOptions _mailingOptions;
+        private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly Services.Agents.IAgentService _agentService;
+    }
+}

--- a/Api/AdministratorServices/IAgencyVerificationService.cs
+++ b/Api/AdministratorServices/IAgencyVerificationService.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Data.Agents;
+
+namespace HappyTravel.Edo.Api.AdministratorServices
+{
+    public interface IAgencyVerificationService
+    {
+        Task<Result> VerifyAsFullyAccessed(int agencyId, CounterpartyContractKind contractKind, string verificationReason);
+        Task<Result> VerifyAsReadOnly(int agencyId, string verificationReason);
+        Task<Result> DeclineVerification(int agencyId, string verificationReason);
+    }
+}

--- a/Api/Controllers/AdministratorControllers/AgenciesController.cs
+++ b/Api/Controllers/AdministratorControllers/AgenciesController.cs
@@ -177,9 +177,9 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.CounterpartyVerification)]
-        public async Task<IActionResult> VerifyReadOnly(int counterpartyId, [FromBody] AgencyReadOnlyVerificationRequest request)
+        public async Task<IActionResult> VerifyReadOnly(int agencyId, [FromBody] AgencyReadOnlyVerificationRequest request)
         {
-            var (isSuccess, _, error) = await _agencyVerificationService.VerifyAsReadOnly(counterpartyId, request.Reason);
+            var (isSuccess, _, error) = await _agencyVerificationService.VerifyAsReadOnly(agencyId, request.Reason);
 
             return isSuccess
                 ? (IActionResult)NoContent()
@@ -197,9 +197,9 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.CounterpartyVerification)]
-        public async Task<IActionResult> VerifyFullAccess(int counterpartyId, [FromBody] AgencyFullAccessVerificationRequest request)
+        public async Task<IActionResult> VerifyFullAccess(int agencyId, [FromBody] AgencyFullAccessVerificationRequest request)
         {
-            var (isSuccess, _, error) = await _agencyVerificationService.VerifyAsFullyAccessed(counterpartyId, request.ContractKind, request.Reason);
+            var (isSuccess, _, error) = await _agencyVerificationService.VerifyAsFullyAccessed(agencyId, request.ContractKind, request.Reason);
 
             return isSuccess
                 ? (IActionResult)NoContent()
@@ -217,9 +217,9 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.CounterpartyVerification)]
-        public async Task<IActionResult> DeclineVerification(int counterpartyId, [FromBody] AgencyDeclinedVerificationRequest request)
+        public async Task<IActionResult> DeclineVerification(int agencyId, [FromBody] AgencyDeclinedVerificationRequest request)
         {
-            var (isSuccess, _, error) = await _agencyVerificationService.DeclineVerification(counterpartyId, request.Reason);
+            var (isSuccess, _, error) = await _agencyVerificationService.DeclineVerification(agencyId, request.Reason);
 
             return isSuccess
                 ? (IActionResult)NoContent()

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -201,6 +201,30 @@
             </summary>
             <param name="agencyId">Id of the agency.</param>
         </member>
+        <member name="M:HappyTravel.Edo.Api.Controllers.AdministratorControllers.AgenciesController.VerifyReadOnly(System.Int32,HappyTravel.Edo.Api.Models.Management.AgencyReadOnlyVerificationRequest)">
+            <summary>
+                Sets agency verified read only.
+            </summary>
+            <param name="counterpartyId">Id of the agency to verify.</param>
+            <param name="request">Verification details.</param>
+            <returns></returns>
+        </member>
+        <member name="M:HappyTravel.Edo.Api.Controllers.AdministratorControllers.AgenciesController.VerifyFullAccess(System.Int32,HappyTravel.Edo.Api.Models.Management.AgencyFullAccessVerificationRequest)">
+            <summary>
+                Sets agency fully verified.
+            </summary>
+            <param name="counterpartyId">Id of the agency to verify.</param>
+            <param name="request">Verification details.</param>
+            <returns></returns>
+        </member>
+        <member name="M:HappyTravel.Edo.Api.Controllers.AdministratorControllers.AgenciesController.DeclineVerification(System.Int32,HappyTravel.Edo.Api.Models.Management.AgencyDeclinedVerificationRequest)">
+            <summary>
+                Sets agency declined verification.
+            </summary>
+            <param name="counterpartyId">Id of the agency to verify.</param>
+            <param name="request">Verification details.</param>
+            <returns></returns>
+        </member>
         <member name="M:HappyTravel.Edo.Api.Controllers.AdministratorControllers.AgencyAccountsController.GetAgencyAccounts(System.Int32)">
             <summary>
                 Gets agency accounts list
@@ -3547,6 +3571,26 @@
         <member name="P:HappyTravel.Edo.Api.Models.Management.Administrators.RichAdministratorInfo.IsActive">
             <summary>
             Flag of administrator activity state
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Management.AgencyDeclinedVerificationRequest.Reason">
+            <summary>
+                Verify reason.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Management.AgencyFullAccessVerificationRequest.ContractKind">
+            <summary>
+            Contract type
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Management.AgencyFullAccessVerificationRequest.Reason">
+            <summary>
+            Verify reason.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Management.AgencyReadOnlyVerificationRequest.Reason">
+            <summary>
+                Verify reason.
             </summary>
         </member>
         <member name="P:HappyTravel.Edo.Api.Models.Management.CounterpartyDeclinedVerificationRequest.Reason">

--- a/Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -531,6 +531,7 @@ namespace HappyTravel.Edo.Api.Infrastructure
             services.AddTransient<ICounterpartyService, CounterpartyService>();
             services.AddTransient<ICounterpartyManagementService, CounterpartyManagementService>();
             services.AddTransient<ICounterpartyVerificationService, CounterpartyVerificationService>();
+            services.AddTransient<IAgencyVerificationService, AgencyVerificationService>();
             
             services.AddTransient<Services.Agents.IAgentService, Services.Agents.AgentService>();
             services.AddTransient<IAgentRolesService, AgentRolesService>();

--- a/Api/Models/Management/AgencyDeclinedVerificationRequest.cs
+++ b/Api/Models/Management/AgencyDeclinedVerificationRequest.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
+
+namespace HappyTravel.Edo.Api.Models.Management
+{
+    public readonly struct AgencyDeclinedVerificationRequest
+    {
+        [JsonConstructor]
+        public AgencyDeclinedVerificationRequest(string reason)
+        {
+            Reason = reason;
+        }
+
+
+        /// <summary>
+        ///     Verify reason.
+        /// </summary>
+        [Required]
+        public string Reason { get; }
+    }
+}

--- a/Api/Models/Management/AgencyFullAccessVerificationRequest.cs
+++ b/Api/Models/Management/AgencyFullAccessVerificationRequest.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+using HappyTravel.Edo.Data.Agents;
+using Newtonsoft.Json;
+
+namespace HappyTravel.Edo.Api.Models.Management
+{
+    public readonly struct AgencyFullAccessVerificationRequest
+    {
+        [JsonConstructor]
+        public AgencyFullAccessVerificationRequest(CounterpartyContractKind contractKind, string reason)
+        {
+            ContractKind = contractKind;
+            Reason = reason;
+        }
+
+
+        /// <summary>
+        /// Contract type
+        /// </summary>
+        [Required]
+        public CounterpartyContractKind ContractKind { get; }
+
+        /// <summary>
+        /// Verify reason.
+        /// </summary>
+        [Required]
+        public string Reason { get; }
+    }
+}

--- a/Api/Models/Management/AgencyReadOnlyVerificationRequest.cs
+++ b/Api/Models/Management/AgencyReadOnlyVerificationRequest.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
+
+namespace HappyTravel.Edo.Api.Models.Management
+{
+    public readonly struct AgencyReadOnlyVerificationRequest
+    {
+        [JsonConstructor]
+        public AgencyReadOnlyVerificationRequest(string reason)
+        {
+            Reason = reason;
+        }
+
+
+        /// <summary>
+        ///     Verify reason.
+        /// </summary>
+        [Required]
+        public string Reason { get; }
+    }
+}

--- a/Api/Models/Management/AuditEvents/AgencyVerifiedEventData.cs
+++ b/Api/Models/Management/AuditEvents/AgencyVerifiedEventData.cs
@@ -1,0 +1,19 @@
+using HappyTravel.Edo.Common.Enums;
+
+namespace HappyTravel.Edo.Api.Models.Management.AuditEvents
+{
+    public readonly struct AgencyVerifiedEventData
+    {
+        public AgencyVerifiedEventData(int agencyId, string reason, CounterpartyStates verificationState)
+        {
+            AgencyId = agencyId;
+            Reason = reason;
+            VerificationState = verificationState;
+        }
+
+
+        public int AgencyId { get; }
+        public string Reason { get; }
+        public CounterpartyStates VerificationState { get; }
+    }
+}

--- a/HappyTravel.Edo.Common/Enums/ManagementEventType.cs
+++ b/HappyTravel.Edo.Common/Enums/ManagementEventType.cs
@@ -4,6 +4,7 @@ namespace HappyTravel.Edo.Common.Enums
     {
         None = 0,
         CounterpartyVerification = 10,
+        AgencyVerification = 11,
         AdministratorRegistration = 20,
         CounterpartyDeactivation = 30,
         AgencyDeactivation = 40,

--- a/HappyTravel.Edo.Data/Agents/Agency.cs
+++ b/HappyTravel.Edo.Data/Agents/Agency.cs
@@ -22,7 +22,7 @@ namespace HappyTravel.Edo.Data.Agents
         public string Website { get; set; }
         public DateTime Created { get; set; }
         public DateTime Modified { get; set; }
-        public DateTime Verified { get; set; }
+        public DateTime? Verified { get; set; }
         public int? ParentId { get; set; }
         public bool IsActive { get; set; }
         public List<int> Ancestors { get; init; } = new();

--- a/HappyTravel.Edo.Data/Agents/Agency.cs
+++ b/HappyTravel.Edo.Data/Agents/Agency.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using HappyTravel.Edo.Common.Enums;
 using HappyTravel.Money.Enums;
 
 namespace HappyTravel.Edo.Data.Agents
@@ -21,10 +22,14 @@ namespace HappyTravel.Edo.Data.Agents
         public string Website { get; set; }
         public DateTime Created { get; set; }
         public DateTime Modified { get; set; }
+        public DateTime Verified { get; set; }
         public int? ParentId { get; set; }
         public bool IsActive { get; set; }
         public List<int> Ancestors { get; init; } = new();
         public string CountryHtId { get; init; }
         public string LocalityHtId { get; init; }
+        public CounterpartyContractKind? ContractKind { get; set; }
+        public string VerificationReason { get; set; }
+        public CounterpartyStates VerificationState { get; set; }
     }
 }

--- a/HappyTravel.Edo.Data/EdoContext.cs
+++ b/HappyTravel.Edo.Data/EdoContext.cs
@@ -305,11 +305,12 @@ namespace HappyTravel.Edo.Data
                 agency.HasIndex(a => a.CounterpartyId);
                 agency.HasIndex(a => a.Ancestors)
                     .HasMethod("gin");
-                agency.Property(c => c.Address).IsRequired();
-                agency.Property(c => c.City).IsRequired();
-                agency.Property(c => c.CountryCode).IsRequired();
-                agency.Property(c => c.Phone).IsRequired();
-                agency.Property(c => c.PreferredCurrency).IsRequired();
+                agency.Property(a => a.Address).IsRequired();
+                agency.Property(a => a.City).IsRequired();
+                agency.Property(a => a.CountryCode).IsRequired();
+                agency.Property(a => a.Phone).IsRequired();
+                agency.Property(a => a.PreferredCurrency).IsRequired();
+                agency.Property(a => a.VerificationState).IsRequired().HasDefaultValue(CounterpartyStates.PendingVerification);
             });
         }
 

--- a/HappyTravel.Edo.Data/Migrations/20211020073936_AddVerificationAgencyFields.Designer.cs
+++ b/HappyTravel.Edo.Data/Migrations/20211020073936_AddVerificationAgencyFields.Designer.cs
@@ -7,15 +7,17 @@ using HappyTravel.Edo.Data.Agents;
 using HappyTravel.Edo.Data.Bookings;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace HappyTravel.Edo.Data.Migrations
 {
     [DbContext(typeof(EdoContext))]
-    partial class EdoContextModelSnapshot : ModelSnapshot
+    [Migration("20211020073936_AddVerificationAgencyFields")]
+    partial class AddVerificationAgencyFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HappyTravel.Edo.Data/Migrations/20211020073936_AddVerificationAgencyFields.cs
+++ b/HappyTravel.Edo.Data/Migrations/20211020073936_AddVerificationAgencyFields.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace HappyTravel.Edo.Data.Migrations
+{
+    public partial class AddVerificationAgencyFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ContractKind",
+                table: "Agencies",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "VerificationReason",
+                table: "Agencies",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "VerificationState",
+                table: "Agencies",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Verified",
+                table: "Agencies",
+                type: "timestamp without time zone",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ContractKind",
+                table: "Agencies");
+
+            migrationBuilder.DropColumn(
+                name: "VerificationReason",
+                table: "Agencies");
+
+            migrationBuilder.DropColumn(
+                name: "VerificationState",
+                table: "Agencies");
+
+            migrationBuilder.DropColumn(
+                name: "Verified",
+                table: "Agencies");
+        }
+    }
+}

--- a/HappyTravel.Edo.DirectApi/HappyTravel.Edo.DirectApi.xml
+++ b/HappyTravel.Edo.DirectApi/HappyTravel.Edo.DirectApi.xml
@@ -287,6 +287,46 @@
             Indicates that rates must be sold as a package
             </summary>
         </member>
+        <member name="P:HappyTravel.Edo.DirectApi.Models.RoomContractSetAvailability.AvailabilityId">
+            <summary>
+                The availability ID.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.DirectApi.Models.RoomContractSetAvailability.CheckInDate">
+            <summary>
+                The check-in date.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.DirectApi.Models.RoomContractSetAvailability.CheckOutDate">
+            <summary>
+                The check-out date.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.DirectApi.Models.RoomContractSetAvailability.NumberOfNights">
+            <summary>
+                The number of nights to stay.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.DirectApi.Models.RoomContractSetAvailability.RoomContractSet">
+            <summary>
+                Information about a selected room contract set.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.DirectApi.Models.RoomContractSetAvailability.AvailablePaymentMethods">
+            <summary>
+            List of available payment methods
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.DirectApi.Models.RoomContractSetAvailability.CountryHtId">
+            <summary>
+            Country of accommodation
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.DirectApi.Models.RoomContractSetAvailability.LocalityHtId">
+            <summary>
+            Locality of accommodation
+            </summary>
+        </member>
         <member name="P:HappyTravel.Edo.DirectApi.Models.WideAvailabilityResult.MinPrice">
             <summary>
             Minimal room contract set price


### PR DESCRIPTION
https://github.com/happy-travel/agent-app-project/issues/724

Note that we will have to change notifications, but only when we completely move to agency verification.

We will also need to move all current verification data from `Counterparties` to `Agencies`, also later. 

Old `Counterparty` verification endpoints:
```
api/{v:apiVersion}/admin/counterparties/{counterpartyId}/verify-read-only
api/{v:apiVersion}/admin/counterparties/{counterpartyId}/verify-full-access
api/{v:apiVersion}/admin/counterparties/{counterpartyId}/decline-verification
```

New `Agency` verification endpoints:
```
api/{v:apiVersion}/admin/agencies/{agencyId}/verify-read-only
api/{v:apiVersion}/admin/agencies/{agencyId}/verify-full-access
api/{v:apiVersion}/admin/agencies/{agencyId}/decline-verification
```