### PR TITLE
Added local booking reference code

### DIFF
--- a/Api/appsettings.Local.json
+++ b/Api/appsettings.Local.json
@@ -49,5 +49,8 @@
       "ConnectionString": "mongodb://admin:password@localhost:27017",
       "DatabaseName": "edo"
     }
+  },
+  "TagProcessing": {
+    "ReferenceCodePrefix": "LOC"
   }
 }


### PR DESCRIPTION
This is to make bookings made locally to not frighten with e-mails.
Bookings will have code: `LOC-HTL-AE-000TJ5-01` instead of `HTL-AE-000TJ5-01`