### PR TITLE
Added more meaningful values for deadline policy processor failures

### DIFF
--- a/Api/Services/Accommodations/Availability/DeadlinePolicyProcessor.cs
+++ b/Api/Services/Accommodations/Availability/DeadlinePolicyProcessor.cs
@@ -14,11 +14,20 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability
                 ? TimeSpan.Zero
                 : shiftValue;
 
+            if (deadline.Date == default(DateTime))
+                throw new ArgumentException($"Deadline date '{deadline.Date}' is invalid", nameof(deadline.Date));
+            
+            if (checkInDate == default(DateTime))
+                throw new ArgumentException($"Check in date '{checkInDate}' is invalid", nameof(checkInDate));
+                
             var shiftedDeadlineDate = ShiftDate(deadline.Date, checkInDate, shiftValue);
             List<CancellationPolicy> shiftedPolicies = new List<CancellationPolicy>();
             foreach (var policy in deadline.Policies)
             {
-                var shiftedPolicyDate = ShiftDate(policy.FromDate, policy.FromDate, shiftValue);
+                if (policy.FromDate == default)
+                    throw new ArgumentException($"Policy date '{policy.FromDate}' is invalid", nameof(policy.FromDate));
+                
+                var shiftedPolicyDate = ShiftDate(policy.FromDate, checkInDate, shiftValue);
                 var percentage = Math.Round(policy.Percentage, 2, MidpointRounding.AwayFromZero);
                 shiftedPolicies.Add(new CancellationPolicy(shiftedPolicyDate, percentage));
             }


### PR DESCRIPTION
These errors are often related to connector errors but need to be highlighted instead of this error:

https://sentry1.happytravel.com/organizations/happytravel/issues/3745/?query=is%3Aunresolved&statsPeriod=14d