### PR TITLE
fixed memory leak

### DIFF
--- a/Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -553,7 +553,7 @@ namespace HappyTravel.Edo.Api.Infrastructure
             services.AddTransient<IPaymentHistoryService, PaymentHistoryService>();
             services.AddTransient<IBookingDocumentsService, BookingDocumentsService>();
             services.AddTransient<IBookingAuditLogService, BookingAuditLogService>();
-            services.AddTransient<ISupplierConnectorManager, SupplierConnectorManager>();
+            services.AddSingleton<ISupplierConnectorManager, SupplierConnectorManager>();
             services.AddTransient<IWideAvailabilitySearchService, WideAvailabilitySearchService>();
             services.AddTransient<IWideAvailabilityPriceProcessor, WideAvailabilityPriceProcessor>();
             services.AddTransient<IWideAvailabilityAccommodationsStorage, WideAvailabilityAccommodationsStorage>();


### PR DESCRIPTION
IOptionsMonitor<T> hold link to method and service cannot be collected by GC
Not need to create new instance of service on every usage