### PR TITLE
Feature/aa 1095 add implementation transfer cancellation policy description to agent app

### DIFF
--- a/Api/HappyTravel.Edo.Api.csproj
+++ b/Api/HappyTravel.Edo.Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="6.0.1" />
-    <PackageReference Include="CSharpFunctionalExtensions" Version="2.27.1" />
+    <PackageReference Include="CSharpFunctionalExtensions" Version="2.27.2" />
     <PackageReference Include="CsvHelper" Version="27.2.1" />
     <PackageReference Include="Elasticsearch.Net" Version="7.16.0" />
     <PackageReference Include="FloxDc.CacheFlow" Version="1.10.0" />
@@ -28,7 +28,7 @@
     <PackageReference Include="HappyTravel.ConsulKeyValueClient.ConfigurationProvider" Version="1.6.1" />
     <PackageReference Include="HappyTravel.CurrencyConverter" Version="1.0.5" />
     <PackageReference Include="HappyTravel.DataFormatters" Version="1.2.1" />
-    <PackageReference Include="HappyTravel.EdoContracts" Version="2.2.8" />
+    <PackageReference Include="HappyTravel.EdoContracts" Version="2.2.9" />
     <PackageReference Include="HappyTravel.ErrorHandling" Version="1.2.3" />
     <PackageReference Include="HappyTravel.MailSender" Version="1.4.0" />
     <PackageReference Include="HappyTravel.MapperContracts" Version="1.1.1" />

--- a/Api/Services/Accommodations/Availability/DeadlinePolicyProcessor.cs
+++ b/Api/Services/Accommodations/Availability/DeadlinePolicyProcessor.cs
@@ -29,7 +29,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability
                 
                 var shiftedPolicyDate = ShiftDate(policy.FromDate, checkInDate, shiftValue);
                 var percentage = Math.Round(policy.Percentage, 2, MidpointRounding.AwayFromZero);
-                shiftedPolicies.Add(new CancellationPolicy(shiftedPolicyDate, percentage));
+                shiftedPolicies.Add(new CancellationPolicy(shiftedPolicyDate, percentage, policy.Remark));
             }
 
             var shiftedDeadline = new Deadline(shiftedDeadlineDate, shiftedPolicies, deadline.Remarks, deadline.IsFinal);

--- a/Api/Services/Accommodations/ContractsMappingExtensions.cs
+++ b/Api/Services/Accommodations/ContractsMappingExtensions.cs
@@ -56,7 +56,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations
 
         private static CancellationPolicy ToCancellationPolicy(EdoContracts.Accommodations.Internals.CancellationPolicy policy)
         {
-            return new (policy.FromDate, policy.Percentage);
+            return new (policy.FromDate, policy.Percentage, policy.Remark);
         }
         
         

--- a/Api/Services/Accommodations/DeadlineMerger.cs
+++ b/Api/Services/Accommodations/DeadlineMerger.cs
@@ -47,7 +47,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations
                             .FirstOrDefault()
                     );
 
-                    return new CancellationPolicy(date, CalculatePercent(amount));
+                    return new CancellationPolicy(date, CalculatePercent(amount), null);    // TODO: Need clarify
                 })
                 .ToList();
 

--- a/Api/Services/Accommodations/DeadlineMerger.cs
+++ b/Api/Services/Accommodations/DeadlineMerger.cs
@@ -47,7 +47,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations
                             .FirstOrDefault()
                     );
 
-                    return new CancellationPolicy(date, CalculatePercent(amount), null);    // TODO: Need clarify
+                    return new CancellationPolicy(date, CalculatePercent(amount), null);
                 })
                 .ToList();
 

--- a/HappyTravel.Edo.Data/Bookings/CancellationPolicy.cs
+++ b/HappyTravel.Edo.Data/Bookings/CancellationPolicy.cs
@@ -9,13 +9,15 @@ namespace HappyTravel.Edo.Data.Bookings
         private CancellationPolicy() { }
 
         [JsonConstructor]
-        public CancellationPolicy(DateTime fromDate, double percentage)
+        public CancellationPolicy(DateTime fromDate, double percentage, string remark)
         {
             FromDate = fromDate;
             Percentage = percentage;
+            Remark = remark;
         }
         
         public DateTime FromDate { get; set; }
         public double Percentage { get; set; }
+        public string Remark { get; set; }
     }
 }

--- a/HappyTravel.Edo.Data/HappyTravel.Edo.Data.csproj
+++ b/HappyTravel.Edo.Data/HappyTravel.Edo.Data.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="HappyTravel.MapperContracts" Version="1.1.1" />
-    <PackageReference Include="HappyTravel.EdoContracts" Version="2.2.8" />
+    <PackageReference Include="HappyTravel.EdoContracts" Version="2.2.9" />
     <PackageReference Include="HappyTravel.SuppliersCatalog" Version="0.11.0" />
     <PackageReference Include="HappyTravel.VaultClient" Version="1.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />

--- a/HappyTravel.Edo.Notifications/HappyTravel.Edo.Notifications.csproj
+++ b/HappyTravel.Edo.Notifications/HappyTravel.Edo.Notifications.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CSharpFunctionalExtensions" Version="2.27.1" />
+    <PackageReference Include="CSharpFunctionalExtensions" Version="2.27.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/HappyTravel.Edo.UnitTests/Tests/Extensions/BookingExtensionsTests/MoneyRefundCalculation.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Extensions/BookingExtensionsTests/MoneyRefundCalculation.cs
@@ -73,7 +73,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Extensions.BookingExtensionsTests
                         new DateTime(2020, 1, 1),
                         new List<CancellationPolicy>
                         {
-                            new CancellationPolicy(fromDate: new DateTime(2020, 1, 3), 0.3d)
+                            new CancellationPolicy(fromDate: new DateTime(2020, 1, 3), 0.3d, null)
                         }, null, true),
                     price: new MoneyAmount(100m, Currencies.USD))
             };
@@ -95,7 +95,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Extensions.BookingExtensionsTests
                         new DateTime(2020, 2, 1),
                         new List<CancellationPolicy>
                         {
-                            new(fromDate: new DateTime(2020, 2, 1), 50.53533d)
+                            new(fromDate: new DateTime(2020, 2, 1), 50.53533d, null)
                         }, null, true),
                     price: new MoneyAmount(100m, Currencies.USD))
             };
@@ -127,10 +127,10 @@ namespace HappyTravel.Edo.UnitTests.Tests.Extensions.BookingExtensionsTests
                         new DateTime(2020, 1, 3),
                         new List<CancellationPolicy>
                         {
-                            new CancellationPolicy(fromDate: new DateTime(2020, 1, 3), 30d),
-                            new CancellationPolicy(fromDate: new DateTime(2020, 1, 5), 60d),
-                            new CancellationPolicy(fromDate: new DateTime(2020, 1, 8), 80d),
-                            new CancellationPolicy(fromDate: new DateTime(2020, 1, 10), 100d),
+                            new CancellationPolicy(fromDate: new DateTime(2020, 1, 3), 30d, null),
+                            new CancellationPolicy(fromDate: new DateTime(2020, 1, 5), 60d, null),
+                            new CancellationPolicy(fromDate: new DateTime(2020, 1, 8), 80d, null),
+                            new CancellationPolicy(fromDate: new DateTime(2020, 1, 10), 100d, null),
                         }, null, true),
                     price: new MoneyAmount(100m, Currencies.USD))
             };
@@ -155,7 +155,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Extensions.BookingExtensionsTests
                         deadlineDate,
                         new List<CancellationPolicy>
                         {
-                            new(fromDate: deadlineDate, 72.00)
+                            new(fromDate: deadlineDate, 72.00, null)
                         }, null, true),
                     price: new MoneyAmount(100m, Currencies.USD),
                     isAdvancePurchaseRate: true)

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Accommodations/Availability/DeadlinePolicyProcessorTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Accommodations/Availability/DeadlinePolicyProcessorTests.cs
@@ -115,10 +115,10 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability
 
         private static readonly List<CancellationPolicy> Policies = new List<CancellationPolicy>
         {
-            new CancellationPolicy(new DateTime(2021, 1, 16), 1d),
-            new CancellationPolicy(new DateTime(2021, 1, 17), 2d),
-            new CancellationPolicy(new DateTime(2021, 1, 18), 3d),
-            new CancellationPolicy(new DateTime(2021, 1, 19), 4d),
+            new CancellationPolicy(new DateTime(2021, 1, 16), 1d, null),
+            new CancellationPolicy(new DateTime(2021, 1, 17), 2d, null),
+            new CancellationPolicy(new DateTime(2021, 1, 18), 3d, null),
+            new CancellationPolicy(new DateTime(2021, 1, 19), 4d, null),
         };
     }
 }


### PR DESCRIPTION
Added remark to cancellation policy. It is necessary to clarify how to deal with remarks when merging cancellation policies.