### PR TITLE
Feature/aa 1324 add endpoint to manage countries in market

### DIFF
--- a/Api/AdministratorServices/AdminAgencyManagementService.cs
+++ b/Api/AdministratorServices/AdminAgencyManagementService.cs
@@ -52,17 +52,17 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                     from a in _context.Agencies
                     join c in _context.Countries on a.CountryCode equals c.Code
                     join ra in _context.Agencies on a.Ancestors.Any() ? a.Ancestors[0] : a.Id equals ra.Id
-                    from markupFormula in _context.DisplayMarkupFormulas.Where(f => f.AgencyId == a.Id && f.AgentId == null).DefaultIfEmpty() 
+                    from markupFormula in _context.DisplayMarkupFormulas.Where(f => f.AgencyId == a.Id && f.AgentId == null).DefaultIfEmpty()
                     where a.Id == agencyId
-                    select a.ToAgencyInfo(a.ContractKind, 
-                        ra.VerificationState, 
+                    select a.ToAgencyInfo(a.ContractKind,
+                        ra.VerificationState,
                         ra.Verified != null
                             ? ra.Verified.Value.DateTime
-                            : null, 
-                        c.Names, 
+                            : null,
+                        c.Names,
                         languageCode,
-                        markupFormula == null 
-                            ? string.Empty 
+                        markupFormula == null
+                            ? string.Empty
                             : markupFormula.DisplayFormula))
                 .SingleOrDefaultAsync();
 
@@ -79,20 +79,20 @@ namespace HappyTravel.Edo.Api.AdministratorServices
 
         public IQueryable<AdminViewAgencyInfo> GetRootAgencies(string languageCode = LocalizationHelper.DefaultLanguageCode)
             => from a in _context.Agencies
-                join c in _context.Countries on a.CountryCode equals c.Code
-                from markupFormula in _context.DisplayMarkupFormulas.Where(f => f.AgencyId == a.Id && f.AgentId == null).DefaultIfEmpty()
-                where a.ParentId == null
-                select new AdminViewAgencyInfo
-                {
-                    Id = a.Id,
-                    Name = a.Name,
-                    City = a.City,
-                    CountryName = c.Names.RootElement.GetProperty(languageCode).GetString(),
-                    Created = a.Created.DateTime,
-                    VerificationState = a.VerificationState,
-                    AccountManagerName = string.Empty,
-                    IsActive = a.IsActive
-                };
+               join c in _context.Countries on a.CountryCode equals c.Code
+               from markupFormula in _context.DisplayMarkupFormulas.Where(f => f.AgencyId == a.Id && f.AgentId == null).DefaultIfEmpty()
+               where a.ParentId == null
+               select new AdminViewAgencyInfo
+               {
+                   Id = a.Id,
+                   Name = a.Name,
+                   City = a.City,
+                   CountryName = c.Names.GetValueOrDefault(languageCode),
+                   Created = a.Created.DateTime,
+                   VerificationState = a.VerificationState,
+                   AccountManagerName = string.Empty,
+                   IsActive = a.IsActive
+               };
 
 
         public Task<List<AgencyInfo>> GetChildAgencies(int parentAgencyId, string languageCode = LocalizationHelper.DefaultLanguageCode)
@@ -100,17 +100,17 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                     from a in _context.Agencies
                     join c in _context.Countries on a.CountryCode equals c.Code
                     join ra in _context.Agencies on a.Ancestors[0] equals ra.Id
-                    from markupFormula in _context.DisplayMarkupFormulas.Where(f => f.AgencyId == a.Id && f.AgentId == null).DefaultIfEmpty()  
+                    from markupFormula in _context.DisplayMarkupFormulas.Where(f => f.AgencyId == a.Id && f.AgentId == null).DefaultIfEmpty()
                     where a.ParentId == parentAgencyId
-                    select a.ToAgencyInfo(a.ContractKind, 
-                        ra.VerificationState, 
+                    select a.ToAgencyInfo(a.ContractKind,
+                        ra.VerificationState,
                         ra.Verified != null
                             ? ra.Verified.Value.DateTime
-                            : null, 
-                        c.Names, 
+                            : null,
+                        c.Names,
                         languageCode,
-                        markupFormula == null 
-                            ? string.Empty 
+                        markupFormula == null
+                            ? string.Empty
                             : markupFormula.DisplayFormula))
                 .ToListAsync();
 
@@ -194,7 +194,7 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                 .Tap(SaveChanges)
                 .Bind(GetUpdatedAgencyInfo);
 
-            
+
             Result Validate(ManagementEditAgencyRequest request)
             {
                 return GenericValidator<ManagementEditAgencyRequest>.Validate(v =>
@@ -269,8 +269,8 @@ namespace HappyTravel.Edo.Api.AdministratorServices
 
             Task<Agency> GetRootAgency(Agency currentAgency)
             {
-                var rootAgencyId = currentAgency.Ancestors.Any() 
-                    ? currentAgency.Ancestors.First() 
+                var rootAgencyId = currentAgency.Ancestors.Any()
+                    ? currentAgency.Ancestors.First()
                     : currentAgency.Id;
                 return _context.Agencies.SingleAsync(ra => ra.Id == rootAgencyId);
             }

--- a/Api/AdministratorServices/Locations/IMarketManagementService.cs
+++ b/Api/AdministratorServices/Locations/IMarketManagementService.cs
@@ -13,7 +13,7 @@ namespace Api.AdministratorServices.Locations
         Task<List<Market>> Get(CancellationToken cancellationToken = default);
         Task<Result> Update(string languageCode, MarketRequest marketRequest, CancellationToken cancellationToken = default);
         Task<Result> Remove(int marketId, CancellationToken cancellationToken = default);
-        Task<Result> AddCountries(CountryRequest countryRequest, CancellationToken cancellationToken = default);
-        Task<Result<List<Country>>> GetCountries(CountryRequest request, CancellationToken cancellationToken = default);
+        Task<Result> UpdateMarketCountries(CountryRequest countryRequest, CancellationToken cancellationToken = default);
+        Task<Result<List<Country>>> GetMarketCountries(CountryRequest request, CancellationToken cancellationToken = default);
     }
 }

--- a/Api/AdministratorServices/Locations/IMarketManagementService.cs
+++ b/Api/AdministratorServices/Locations/IMarketManagementService.cs
@@ -14,6 +14,6 @@ namespace Api.AdministratorServices.Locations
         Task<Result> Update(string languageCode, MarketRequest marketRequest, CancellationToken cancellationToken = default);
         Task<Result> Remove(int marketId, CancellationToken cancellationToken = default);
         Task<Result> UpdateMarketCountries(CountryRequest countryRequest, CancellationToken cancellationToken = default);
-        Task<Result<List<Country>>> GetMarketCountries(CountryRequest request, CancellationToken cancellationToken = default);
+        Task<Result<List<Country>>> GetMarketCountries(int marketId, CancellationToken cancellationToken = default);
     }
 }

--- a/Api/AdministratorServices/Locations/IMarketManagementService.cs
+++ b/Api/AdministratorServices/Locations/IMarketManagementService.cs
@@ -13,5 +13,7 @@ namespace Api.AdministratorServices.Locations
         Task<List<Market>> Get(CancellationToken cancellationToken = default);
         Task<Result> Update(string languageCode, MarketRequest marketRequest, CancellationToken cancellationToken = default);
         Task<Result> Remove(int marketId, CancellationToken cancellationToken = default);
+        Task<Result> AddCountries(CountryRequest countryRequest, CancellationToken cancellationToken = default);
+        Task<Result<List<Country>>> GetCountries(CountryRequest request, CancellationToken cancellationToken = default);
     }
 }

--- a/Api/AdministratorServices/Locations/IMarketManagementStorage.cs
+++ b/Api/AdministratorServices/Locations/IMarketManagementStorage.cs
@@ -8,7 +8,7 @@ namespace Api.AdministratorServices.Locations
     public interface IMarketManagementStorage
     {
         Task<List<Market>> Get(CancellationToken cancellationToken);
-        Task<List<Country>> GetCountries(int marketId, CancellationToken cancellationToken);
+        Task<List<Country>> GetMarketCountries(int marketId, CancellationToken cancellationToken);
         Task<Market?> Get(int marketId, CancellationToken cancellationToken);
         Task Refresh(CancellationToken cancellationToken);
         Task RefreshMarketCountries(int marketId, CancellationToken cancellationToken);

--- a/Api/AdministratorServices/Locations/IMarketManagementStorage.cs
+++ b/Api/AdministratorServices/Locations/IMarketManagementStorage.cs
@@ -8,7 +8,9 @@ namespace Api.AdministratorServices.Locations
     public interface IMarketManagementStorage
     {
         Task<List<Market>> Get(CancellationToken cancellationToken);
+        Task<List<Country>> GetCountries(int marketId, CancellationToken cancellationToken);
         Task<Market?> Get(int marketId, CancellationToken cancellationToken);
         Task Refresh(CancellationToken cancellationToken);
+        Task RefreshCountries(int marketId, CancellationToken cancellationToken);
     }
 }

--- a/Api/AdministratorServices/Locations/IMarketManagementStorage.cs
+++ b/Api/AdministratorServices/Locations/IMarketManagementStorage.cs
@@ -11,6 +11,6 @@ namespace Api.AdministratorServices.Locations
         Task<List<Country>> GetCountries(int marketId, CancellationToken cancellationToken);
         Task<Market?> Get(int marketId, CancellationToken cancellationToken);
         Task Refresh(CancellationToken cancellationToken);
-        Task RefreshCountries(int marketId, CancellationToken cancellationToken);
+        Task RefreshMarketCountries(int marketId, CancellationToken cancellationToken);
     }
 }

--- a/Api/AdministratorServices/Locations/MarketManagementService.cs
+++ b/Api/AdministratorServices/Locations/MarketManagementService.cs
@@ -101,6 +101,7 @@ namespace Api.AdministratorServices.Locations
 
             return ValidateUpdate()
                 .Tap(SetDifferencesToUnkownMarket)
+                .Tap(RefreshUnknownMarketCountries)
                 .Tap(Update)
                 .Tap(() => _marketStorage.RefreshMarketCountries(request.MarketId, cancellationToken));
 
@@ -138,6 +139,7 @@ namespace Api.AdministratorServices.Locations
                     c.MarketId = unknownMarketId;
                 });
 
+                _context.UpdateRange(countriesDifferences);
                 await _context.SaveChangesAsync();
             }
 
@@ -153,6 +155,7 @@ namespace Api.AdministratorServices.Locations
                     c.MarketId = request.MarketId;
                 });
 
+                _context.UpdateRange(countries);
                 await _context.SaveChangesAsync();
             }
 
@@ -162,6 +165,10 @@ namespace Api.AdministratorServices.Locations
                     .Where(m => m.Id == UnknownMarketId)
                     .Select(m => m.Id)
                     .Single();
+
+
+            async Task RefreshUnknownMarketCountries()
+                => await _marketStorage.RefreshMarketCountries(UnknownMarketId, cancellationToken);
         }
 
 

--- a/Api/AdministratorServices/Locations/MarketManagementStorage.cs
+++ b/Api/AdministratorServices/Locations/MarketManagementStorage.cs
@@ -52,18 +52,18 @@ namespace Api.AdministratorServices.Locations
             => await _context.Markets.ToListAsync(cancellationToken);
 
 
-        public async Task RefreshCountries(int marketId, CancellationToken cancellationToken)
+        public async Task RefreshMarketCountries(int marketId, CancellationToken cancellationToken)
         {
-            var countries = await LoadCountriesFromDatabase(cancellationToken);
+            var countries = await LoadCountriesFromDatabase(marketId, cancellationToken);
             await _flow.SetAsync(_flow.BuildKey(nameof(MarketManagementService), MarketsKeyBase, marketId.ToString()), countries, DefaultLocationCachingTime, cancellationToken);
         }
 
 
-        private async Task<List<Country>> LoadCountriesFromDatabase(CancellationToken cancellationToken)
-            => await _context.Countries.ToListAsync(cancellationToken);
+        private async Task<List<Country>> LoadCountriesFromDatabase(int marketId, CancellationToken cancellationToken)
+            => await _context.Countries.Where(c => c.MarketId == marketId).ToListAsync(cancellationToken);
 
 
-        private static TimeSpan DefaultLocationCachingTime => TimeSpan.FromDays(1);
+        private static TimeSpan DefaultLocationCachingTime => TimeSpan.FromMinutes(10);
 
         private const string MarketsKeyBase = "Markets";
 

--- a/Api/AdministratorServices/Locations/MarketManagementStorage.cs
+++ b/Api/AdministratorServices/Locations/MarketManagementStorage.cs
@@ -26,6 +26,13 @@ namespace Api.AdministratorServices.Locations
                     .ToListAsync(cancellationToken), DefaultLocationCachingTime, cancellationToken)!;
 
 
+        public Task<List<Country>> GetCountries(int marketId, CancellationToken cancellationToken)
+            => _flow.GetOrSetAsync(_flow.BuildKey(nameof(MarketManagementService), MarketsKeyBase, marketId.ToString()), async ()
+                => await _context.Countries
+                    .Where(c => c.MarketId == marketId)
+                    .ToListAsync(cancellationToken), DefaultLocationCachingTime, cancellationToken)!;
+
+
         public async Task<Market?> Get(int marketId, CancellationToken cancellationToken)
         {
             var markets = await Get(cancellationToken);
@@ -43,6 +50,17 @@ namespace Api.AdministratorServices.Locations
 
         private async Task<List<Market>> LoadFromDatabase(CancellationToken cancellationToken)
             => await _context.Markets.ToListAsync(cancellationToken);
+
+
+        public async Task RefreshCountries(int marketId, CancellationToken cancellationToken)
+        {
+            var countries = await LoadCountriesFromDatabase(cancellationToken);
+            await _flow.SetAsync(_flow.BuildKey(nameof(MarketManagementService), MarketsKeyBase, marketId.ToString()), countries, DefaultLocationCachingTime, cancellationToken);
+        }
+
+
+        private async Task<List<Country>> LoadCountriesFromDatabase(CancellationToken cancellationToken)
+            => await _context.Countries.ToListAsync(cancellationToken);
 
 
         private static TimeSpan DefaultLocationCachingTime => TimeSpan.FromDays(1);

--- a/Api/AdministratorServices/Locations/MarketManagementStorage.cs
+++ b/Api/AdministratorServices/Locations/MarketManagementStorage.cs
@@ -26,7 +26,7 @@ namespace Api.AdministratorServices.Locations
                     .ToListAsync(cancellationToken), DefaultLocationCachingTime, cancellationToken)!;
 
 
-        public Task<List<Country>> GetCountries(int marketId, CancellationToken cancellationToken)
+        public Task<List<Country>> GetMarketCountries(int marketId, CancellationToken cancellationToken)
             => _flow.GetOrSetAsync(_flow.BuildKey(nameof(MarketManagementService), MarketsKeyBase, marketId.ToString()), async ()
                 => await _context.Countries
                     .Where(c => c.MarketId == marketId)
@@ -48,8 +48,8 @@ namespace Api.AdministratorServices.Locations
         }
 
 
-        private async Task<List<Market>> LoadFromDatabase(CancellationToken cancellationToken)
-            => await _context.Markets.ToListAsync(cancellationToken);
+        private Task<List<Market>> LoadFromDatabase(CancellationToken cancellationToken)
+            => _context.Markets.ToListAsync(cancellationToken);
 
 
         public async Task RefreshMarketCountries(int marketId, CancellationToken cancellationToken)
@@ -59,8 +59,8 @@ namespace Api.AdministratorServices.Locations
         }
 
 
-        private async Task<List<Country>> LoadCountriesFromDatabase(int marketId, CancellationToken cancellationToken)
-            => await _context.Countries.Where(c => c.MarketId == marketId).ToListAsync(cancellationToken);
+        private Task<List<Country>> LoadCountriesFromDatabase(int marketId, CancellationToken cancellationToken)
+            => _context.Countries.Where(c => c.MarketId == marketId).ToListAsync(cancellationToken);
 
 
         private static TimeSpan DefaultLocationCachingTime => TimeSpan.FromMinutes(10);

--- a/Api/Controllers/AdministratorControllers/AdministratorReportsController.cs
+++ b/Api/Controllers/AdministratorControllers/AdministratorReportsController.cs
@@ -42,8 +42,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
                 FileDownloadName = $"direct-connectivity-report-suppliers-{from:g}-{end:g}.csv"
             };
         }
-        
-        
+
+
         /// <summary>
         ///     Returns agency wise direct connectivity report
         /// </summary>
@@ -62,8 +62,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
                 FileDownloadName = $"direct-connectivity-report-agencies-{from:g}-{end:g}.csv"
             };
         }
-        
-        
+
+
         /// <summary>
         ///     Returns agencies productivity report
         /// </summary>
@@ -82,8 +82,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
                 FileDownloadName = $"agencies-productivity-report-{from:g}-{end:g}.csv"
             };
         }
-        
-        
+
+
         /// <summary>
         ///     Returns full bookings report
         /// </summary>
@@ -123,7 +123,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
             };
         }
 
-        
+
         /// <summary>
         ///     Returns confirmed bookings report
         /// </summary>
@@ -162,7 +162,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
             };
         }
 
-        
+
         /// <summary>
         ///     Returns hotel wise booking report 
         /// </summary>
@@ -182,7 +182,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
             };
         }
 
-        
+
         /// <summary>
         ///     Returns cancellation deadline report 
         /// </summary>
@@ -201,8 +201,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
                 FileDownloadName = $"cancellation-deadline-report-{from:g}-{end:g}.csv"
             };
         }
-        
-        
+
+
         /// <summary>
         ///     Returns third party suppliers report 
         /// </summary>
@@ -221,8 +221,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
                 FileDownloadName = $"third-party-suppliers-report-{from:g}-{end:g}.csv"
             };
         }
-        
-        
+
+
         /// <summary>
         ///     Returns vcc bookings report 
         /// </summary>
@@ -241,8 +241,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
                 FileDownloadName = $"vcc-bookings-report-{from:g}-{end:g}.csv"
             };
         }
-        
-        
+
+
         [HttpGet("hotel-productivity-report")]
         [ProducesResponseType(typeof(FileStream), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -258,8 +258,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
                 FileDownloadName = $"hotel-productivity-report-{from:g}-{end:g}.csv"
             };
         }
-        
-        
+
+
         /// <summary>
         ///     Returns cancelled bookings report 
         /// </summary>
@@ -278,8 +278,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
                 FileDownloadName = $"cancelled-bookings-report-{from:g}-{end:g}.csv"
             };
         }
-        
-        
+
+
         private readonly IReportService _reportService;
     }
 }

--- a/Api/Controllers/AdministratorControllers/MarketManagementController.cs
+++ b/Api/Controllers/AdministratorControllers/MarketManagementController.cs
@@ -4,7 +4,7 @@ using Api.AdministratorServices.Locations;
 using Api.Models.Locations;
 using HappyTravel.Edo.Api.Controllers;
 using HappyTravel.Edo.Api.Filters.Authorization.AdministratorFilters;
-using HappyTravel.Edo.Api.Models.Locations;
+using HappyTravel.Edo.Data.Locations;
 using HappyTravel.Edo.Common.Enums.Administrators;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -13,7 +13,7 @@ namespace Api.Controllers.AdministratorControllers
 {
     [ApiController]
     [ApiVersion("1.0")]
-    [Route("api/{v:apiVersion}/admin/locations")]
+    [Route("api/{v:apiVersion}/admin/locations/markets")]
     [Produces("application/json")]
     public class MarketManagementController : BaseController
     {
@@ -28,7 +28,7 @@ namespace Api.Controllers.AdministratorControllers
         /// </summary>
         /// <param name="marketRequest">Market request</param>
         /// <returns></returns>
-        [HttpPost("markets")]
+        [HttpPost]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
@@ -40,7 +40,7 @@ namespace Api.Controllers.AdministratorControllers
         ///     Gets a list of markup markets.
         /// </summary>
         /// <returns>List of markup markets</returns>
-        [HttpGet("markets")]
+        [HttpGet]
         [ProducesResponseType(typeof(List<Market>), StatusCodes.Status200OK)]
         [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
         public async Task<IActionResult> GetMarkets()
@@ -53,11 +53,11 @@ namespace Api.Controllers.AdministratorControllers
         /// <param name="marketId">Market's id</param>
         /// <param name="marketRequest">Market request</param>
         /// <returns></returns>
-        [HttpPut("markets/{marketId:int}")]
+        [HttpPut("{marketId:int}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
-        public async Task<IActionResult> ModifyMarket(int marketId, [FromBody] MarketRequest marketRequest)
+        public async Task<IActionResult> ModifyMarket([FromRoute] int marketId, [FromBody] MarketRequest marketRequest)
             => NoContentOrBadRequest(await _marketManagementService.Update(LanguageCode, new MarketRequest(marketId, marketRequest)));
 
 
@@ -66,12 +66,38 @@ namespace Api.Controllers.AdministratorControllers
         /// </summary>
         /// <param name="marketId">Market's id</param>
         /// <returns></returns>
-        [HttpDelete("markets/{marketId:int}")]
+        [HttpDelete("{marketId:int}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
         public async Task<IActionResult> RemoveMarket([FromRoute] int marketId)
             => NoContentOrBadRequest(await _marketManagementService.Remove(marketId));
+
+
+        /// <summary>
+        ///     Adds countries to market.
+        /// </summary>
+        /// <param name="marketId">Market's id</param>
+        /// <param name="countryRequest">Country request</param>
+        /// <returns></returns>
+        [HttpPut("{marketId:int}/countries")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
+        public async Task<IActionResult> AddCountries([FromRoute] int marketId, [FromBody] CountryRequest countryRequest)
+            => NoContentOrBadRequest(await _marketManagementService.AddCountries(new CountryRequest(marketId, countryRequest)));
+
+
+        /// <summary>
+        ///     Gets a list of countries by market id.
+        /// </summary>
+        /// <param name="marketId">Market's id</param>
+        /// <returns>List of countries of market</returns>
+        [HttpGet("{marketId:int}/countries")]
+        [ProducesResponseType(typeof(List<Country>), StatusCodes.Status200OK)]
+        [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
+        public async Task<IActionResult> GetCountries([FromRoute] int marketId)
+            => OkOrBadRequest(await _marketManagementService.GetCountries(CountryRequest.CreateEmpty(marketId)));
 
 
         private readonly IMarketManagementService _marketManagementService;

--- a/Api/Controllers/AdministratorControllers/MarketManagementController.cs
+++ b/Api/Controllers/AdministratorControllers/MarketManagementController.cs
@@ -97,7 +97,7 @@ namespace Api.Controllers.AdministratorControllers
         [ProducesResponseType(typeof(List<Country>), StatusCodes.Status200OK)]
         [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
         public async Task<IActionResult> GetMarketCountries([FromRoute] int marketId)
-            => OkOrBadRequest(await _marketManagementService.GetMarketCountries(CountryRequest.CreateEmpty(marketId)));
+            => OkOrBadRequest(await _marketManagementService.GetMarketCountries(marketId));
 
 
         private readonly IMarketManagementService _marketManagementService;

--- a/Api/Controllers/AdministratorControllers/MarketManagementController.cs
+++ b/Api/Controllers/AdministratorControllers/MarketManagementController.cs
@@ -75,7 +75,7 @@ namespace Api.Controllers.AdministratorControllers
 
 
         /// <summary>
-        ///     Adds countries to market.
+        ///     Update the composition of the market countries
         /// </summary>
         /// <param name="marketId">Market's id</param>
         /// <param name="countryRequest">Country request</param>
@@ -84,8 +84,8 @@ namespace Api.Controllers.AdministratorControllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
-        public async Task<IActionResult> AddCountries([FromRoute] int marketId, [FromBody] CountryRequest countryRequest)
-            => NoContentOrBadRequest(await _marketManagementService.AddCountries(new CountryRequest(marketId, countryRequest)));
+        public async Task<IActionResult> UpdateMarketCountries([FromRoute] int marketId, [FromBody] CountryRequest countryRequest)
+            => NoContentOrBadRequest(await _marketManagementService.UpdateMarketCountries(new CountryRequest(marketId, countryRequest)));
 
 
         /// <summary>
@@ -96,8 +96,8 @@ namespace Api.Controllers.AdministratorControllers
         [HttpGet("{marketId:int}/countries")]
         [ProducesResponseType(typeof(List<Country>), StatusCodes.Status200OK)]
         [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
-        public async Task<IActionResult> GetCountries([FromRoute] int marketId)
-            => OkOrBadRequest(await _marketManagementService.GetCountries(CountryRequest.CreateEmpty(marketId)));
+        public async Task<IActionResult> GetMarketCountries([FromRoute] int marketId)
+            => OkOrBadRequest(await _marketManagementService.GetMarketCountries(CountryRequest.CreateEmpty(marketId)));
 
 
         private readonly IMarketManagementService _marketManagementService;

--- a/Api/Extensions/AgencyInfoExtensions.cs
+++ b/Api/Extensions/AgencyInfoExtensions.cs
@@ -6,20 +6,21 @@ using HappyTravel.Edo.Api.Models.Agencies;
 using HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.BookingEvaluation;
 using HappyTravel.Edo.Common.Enums;
 using HappyTravel.Edo.Data.Agents;
+using HappyTravel.MultiLanguage;
 
 namespace HappyTravel.Edo.Api.Extensions
 {
     public static class AgencyInfoExtensions
     {
         public static AgencyInfo ToAgencyInfo(this Agency agency, ContractKind? contractKind,
-            AgencyVerificationStates verificationState, DateTime? verificationDate, JsonDocument countryNames, string languageCode, string markupFormula)
+            AgencyVerificationStates verificationState, DateTime? verificationDate, MultiLanguage<string> countryNames, string languageCode, string markupFormula)
             => new AgencyInfo(name: agency.Name,
                 id: agency.Id,
                 address: agency.Address,
                 billingEmail: agency.BillingEmail,
                 city: agency.City,
                 countryCode: agency.CountryCode,
-                countryName: countryNames.RootElement.GetProperty(languageCode).GetString(),
+                countryName: countryNames.GetValueOrDefault(languageCode),
                 fax: agency.Fax,
                 phone: agency.Phone,
                 postalCode: agency.PostalCode,

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -4002,5 +4002,20 @@
             <param name="marketId">Market's id</param>
             <returns></returns>
         </member>
+        <member name="M:Api.Controllers.AdministratorControllers.MarketManagementController.AddCountries(System.Int32,Api.Models.Locations.CountryRequest)">
+            <summary>
+                Adds countries to market.
+            </summary>
+            <param name="marketId">Market's id</param>
+            <param name="countryRequest">Country request</param>
+            <returns></returns>
+        </member>
+        <member name="M:Api.Controllers.AdministratorControllers.MarketManagementController.GetCountries(System.Int32)">
+            <summary>
+                Gets a list of countries by market id.
+            </summary>
+            <param name="marketId">Market's id</param>
+            <returns>List of countries of market</returns>
+        </member>
     </members>
 </doc>

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -4002,15 +4002,15 @@
             <param name="marketId">Market's id</param>
             <returns></returns>
         </member>
-        <member name="M:Api.Controllers.AdministratorControllers.MarketManagementController.AddCountries(System.Int32,Api.Models.Locations.CountryRequest)">
+        <member name="M:Api.Controllers.AdministratorControllers.MarketManagementController.UpdateMarketCountries(System.Int32,Api.Models.Locations.CountryRequest)">
             <summary>
-                Adds countries to market.
+                Update the composition of the market countries
             </summary>
             <param name="marketId">Market's id</param>
             <param name="countryRequest">Country request</param>
             <returns></returns>
         </member>
-        <member name="M:Api.Controllers.AdministratorControllers.MarketManagementController.GetCountries(System.Int32)">
+        <member name="M:Api.Controllers.AdministratorControllers.MarketManagementController.GetMarketCountries(System.Int32)">
             <summary>
                 Gets a list of countries by market id.
             </summary>

--- a/Api/Models/Locations/CountryRequest.cs
+++ b/Api/Models/Locations/CountryRequest.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Api.Models.Locations
+{
+    public readonly struct CountryRequest
+    {
+        [JsonConstructor]
+        public CountryRequest(int? marketId, List<string>? countryCodes)
+        {
+            MarketId = marketId;
+            CountryCodes = countryCodes;
+        }
+
+
+        public CountryRequest(int marketId, CountryRequest countryRequest) : this(marketId, countryRequest.CountryCodes)
+        { }
+
+
+        public int? MarketId { get; }
+        public List<string>? CountryCodes { get; }
+
+        public static CountryRequest CreateEmpty(int marketId) => new(marketId, null);
+    }
+}

--- a/Api/Models/Locations/CountryRequest.cs
+++ b/Api/Models/Locations/CountryRequest.cs
@@ -6,7 +6,7 @@ namespace Api.Models.Locations
     public readonly struct CountryRequest
     {
         [JsonConstructor]
-        public CountryRequest(int? marketId, List<string>? countryCodes)
+        public CountryRequest(int marketId, List<string> countryCodes)
         {
             MarketId = marketId;
             CountryCodes = countryCodes;
@@ -17,9 +17,7 @@ namespace Api.Models.Locations
         { }
 
 
-        public int? MarketId { get; }
-        public List<string>? CountryCodes { get; }
-
-        public static CountryRequest CreateEmpty(int marketId) => new(marketId, null);
+        public int MarketId { get; }
+        public List<string> CountryCodes { get; }
     }
 }

--- a/Api/Models/Reports/DirectConnectivityReports/FullBookingsReportData.cs
+++ b/Api/Models/Reports/DirectConnectivityReports/FullBookingsReportData.cs
@@ -17,7 +17,7 @@ namespace HappyTravel.Edo.Api.Models.Reports.DirectConnectivityReports
         public string ConfirmationNumber { get; init; }
         public string AgencyName { get; init; }
         public string AgentName { get; init; }
-        public JsonDocument AgencyCountry { get; init; }
+        public MultiLanguage<string> AgencyCountry { get; init; }
         public string AgencyCity { get; init; }
         public MultiLanguage<string> AgencyMarket { get; init; }
         public PaymentTypes PaymentMethod { get; init; }

--- a/Api/Services/Locations/CountryService.cs
+++ b/Api/Services/Locations/CountryService.cs
@@ -28,7 +28,7 @@ namespace HappyTravel.Edo.Api.Services.Locations
             return _flow.GetOrSetAsync(_flow.BuildKey(nameof(LocationService), CountriesKeyBase, languageCode, query), async ()
                 => await _context.Countries
                     .Where(c => EF.Functions.ILike(c.Code, query) || EF.Functions.ILike((string)(object)c.Names, @$"%""{languageCode}"":%""%{query}%"))
-                    .Select(c => new Country(c.Code, c.Names.RootElement.GetProperty(languageCode).GetString(), c.MarketId, c.RegionId))
+                    .Select(c => new Country(c.Code, c.Names.GetValueOrDefault(languageCode), c.MarketId, c.RegionId))
                     .ToListAsync(), DefaultLocationCachingTime);
         }
 
@@ -70,7 +70,7 @@ namespace HappyTravel.Edo.Api.Services.Locations
             var cacheKey = _flow.BuildKey(nameof(CountryService), CountriesKeyBase, languageCode);
             return _flow.GetOrSetAsync(cacheKey, async ()
                     => (await _context.Countries.ToListAsync())
-                    .Select(c => new Country(c.Code, c.Names.RootElement.GetProperty(languageCode).GetString(), c.MarketId, c.RegionId)).ToList(),
+                    .Select(c => new Country(c.Code, c.Names.GetValueOrDefault(languageCode), c.MarketId, c.RegionId)).ToList(),
                 DefaultLocationCachingTime);
         }
 

--- a/Api/Services/Reports/Converters/FullBookingsReportDataConverter.cs
+++ b/Api/Services/Reports/Converters/FullBookingsReportDataConverter.cs
@@ -32,7 +32,7 @@ namespace HappyTravel.Edo.Api.Services.Reports.Converters
                 InvoiceNumber = data.InvoiceNumber,
                 AgencyName = data.AgencyName,
                 AgencyCity = data.AgencyCity,
-                AgencyCountry = GetJsonProperty(data.AgencyCountry, "en"),
+                AgencyCountry = data.AgencyCountry.GetValueOrDefault("en"),
                 AgencyMarket = data.AgencyMarket.GetValueOrDefault("en"),
                 AgentName = data.AgentName,
                 PaymentMethod = EnumFormatters.FromDescription(data.PaymentMethod),

--- a/HappyTravel.Edo.Data/Locations/Country.cs
+++ b/HappyTravel.Edo.Data/Locations/Country.cs
@@ -1,11 +1,11 @@
-﻿using System.Text.Json;
+﻿using HappyTravel.MultiLanguage;
 
 namespace HappyTravel.Edo.Data.Locations
 {
     public class Country
     {
         public string Code { get; set; } = string.Empty;
-        public JsonDocument Names { get; set; } = null!;
+        public MultiLanguage<string> Names { get; set; } = null!;
         public int MarketId { get; set; }
         public int RegionId { get; set; }
     }

--- a/HappyTravel.Edo.Data/Migrations/20220406152307_ChangeJsonDocumentToMultilanguageInCountry.Designer.cs
+++ b/HappyTravel.Edo.Data/Migrations/20220406152307_ChangeJsonDocumentToMultilanguageInCountry.Designer.cs
@@ -8,6 +8,7 @@ using HappyTravel.Edo.Data.Bookings;
 using HappyTravel.MultiLanguage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -16,9 +17,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HappyTravel.Edo.Data.Migrations
 {
     [DbContext(typeof(EdoContext))]
-    partial class EdoContextModelSnapshot : ModelSnapshot
+    [Migration("20220406152307_ChangeJsonDocumentToMultilanguageInCountry")]
+    partial class ChangeJsonDocumentToMultilanguageInCountry
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HappyTravel.Edo.Data/Migrations/20220406152307_ChangeJsonDocumentToMultilanguageInCountry.cs
+++ b/HappyTravel.Edo.Data/Migrations/20220406152307_ChangeJsonDocumentToMultilanguageInCountry.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HappyTravel.Edo.Data.Migrations
+{
+    public partial class ChangeJsonDocumentToMultilanguageInCountry : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/MarketManagementServiceTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/MarketManagementServiceTests.cs
@@ -144,7 +144,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices
             var marketManagementService = new MarketManagementService(_edoContextMock.Object, _marketManagementStorageMock.Object);
 
 
-            var (_, isFailure, countriesResponse) = await marketManagementService.GetCountries(countryRequest, It.IsAny<CancellationToken>());
+            var (_, isFailure, countriesResponse) = await marketManagementService.GetMarketCountries(countryRequest, It.IsAny<CancellationToken>());
 
             Assert.Equal(countriesResponse.Count, countriesById.Count);
             Assert.All(countriesResponse, m => Assert.NotNull(m.Names.GetValueOrDefault("en")));
@@ -163,7 +163,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices
             var marketManagementService = new MarketManagementService(_edoContextMock.Object, _marketManagementStorageMock.Object);
 
 
-            var (_, isFailure, response, error) = await marketManagementService.GetCountries(countryRequest, It.IsAny<CancellationToken>());
+            var (_, isFailure, response, error) = await marketManagementService.GetMarketCountries(countryRequest, It.IsAny<CancellationToken>());
 
             Assert.True(isFailure);
         }
@@ -176,7 +176,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices
             var listCodes = new List<string> { "GB", "US" };
             var countriesRequest = new CountryRequest(marketId, listCodes);
 
-            var (_, isFailure, error) = await _marketManagementService.AddCountries(countriesRequest, It.IsAny<CancellationToken>());
+            var (_, isFailure, error) = await _marketManagementService.UpdateMarketCountries(countriesRequest, It.IsAny<CancellationToken>());
 
             Assert.False(isFailure);
         }
@@ -189,7 +189,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices
             var listCodes = new List<string> { "GB", "US" };
             var countriesRequest = new CountryRequest(marketId, listCodes);
 
-            var (_, isFailure, error) = await _marketManagementService.AddCountries(countriesRequest, It.IsAny<CancellationToken>());
+            var (_, isFailure, error) = await _marketManagementService.UpdateMarketCountries(countriesRequest, It.IsAny<CancellationToken>());
 
             Assert.True(isFailure);
         }
@@ -202,7 +202,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices
             var listCodes = new List<string> { "GB", "US", "AL" };
             var countriesRequest = new CountryRequest(marketId, listCodes);
 
-            var (_, isFailure, error) = await _marketManagementService.AddCountries(countriesRequest, It.IsAny<CancellationToken>());
+            var (_, isFailure, error) = await _marketManagementService.UpdateMarketCountries(countriesRequest, It.IsAny<CancellationToken>());
 
             Assert.True(isFailure);
         }

--- a/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/MarketManagementServiceTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/MarketManagementServiceTests.cs
@@ -147,7 +147,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices
             var (_, isFailure, countriesResponse) = await marketManagementService.GetCountries(countryRequest, It.IsAny<CancellationToken>());
 
             Assert.Equal(countriesResponse.Count, countriesById.Count);
-            Assert.All(countriesResponse, m => Assert.NotNull(m.Names.RootElement.GetProperty("en")));
+            Assert.All(countriesResponse, m => Assert.NotNull(m.Names.GetValueOrDefault("en")));
         }
 
 
@@ -245,37 +245,37 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices
             new Country
             {
                 Code = "RU",
-                Names = JsonDocument.Parse("{\"en\": \"Russia\"}"),
+                Names = new MultiLanguage<string> { En = "Russia" },
                 MarketId = 2
             },
             new Country
             {
                 Code = "KZ",
-                Names = JsonDocument.Parse("{\"en\": \"Kazakhstan\"}"),
+                Names = new MultiLanguage<string> { En = "Kazakhstan" },
                 MarketId = 2
             },
             new Country
             {
                 Code = "KR",
-                Names = JsonDocument.Parse("{\"en\": \"Kyrgyzstan\"}"),
+                Names = new MultiLanguage<string> { En = "Kyrgyzstan" },
                 MarketId = 2
             },
             new Country
             {
                 Code = "GB",
-                Names = JsonDocument.Parse("{\"en\": \"Great Britan\"}"),
+                Names = new MultiLanguage<string> { En = "Great Britan" },
                 MarketId = 1
             },
             new Country
             {
                 Code = "US",
-                Names = JsonDocument.Parse("{\"en\": \"United States\"}"),
+                Names = new MultiLanguage<string> { En = "United States" },
                 MarketId = 1
             },
             new Country
             {
                 Code = "AL",
-                Names = JsonDocument.Parse("{\"en\": \"Albania\"}"),
+                Names = new MultiLanguage<string> { En = "Albania" },
                 MarketId = 3
             },
         };

--- a/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/MarketManagementServiceTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/MarketManagementServiceTests.cs
@@ -137,14 +137,13 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices
         {
             const int marketId = 2;
             var countriesById = countries.Where(c => c.MarketId == marketId).ToList();
-            var countryRequest = CountryRequest.CreateEmpty(marketId);
             _marketManagementStorageMock
-                .Setup(m => m.GetCountries(marketId, It.IsAny<CancellationToken>()))
+                .Setup(m => m.GetMarketCountries(marketId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(countriesById);
             var marketManagementService = new MarketManagementService(_edoContextMock.Object, _marketManagementStorageMock.Object);
 
 
-            var (_, isFailure, countriesResponse) = await marketManagementService.GetMarketCountries(countryRequest, It.IsAny<CancellationToken>());
+            var (_, isFailure, countriesResponse) = await marketManagementService.GetMarketCountries(marketId, It.IsAny<CancellationToken>());
 
             Assert.Equal(countriesResponse.Count, countriesById.Count);
             Assert.All(countriesResponse, m => Assert.NotNull(m.Names.GetValueOrDefault("en")));
@@ -156,14 +155,13 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices
         {
             const int marketId = 4;
             var countriesById = countries.Where(c => c.MarketId == marketId).ToList();
-            var countryRequest = CountryRequest.CreateEmpty(marketId);
             _marketManagementStorageMock
-                .Setup(m => m.GetCountries(marketId, It.IsAny<CancellationToken>()))
+                .Setup(m => m.GetMarketCountries(marketId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(countriesById);
             var marketManagementService = new MarketManagementService(_edoContextMock.Object, _marketManagementStorageMock.Object);
 
 
-            var (_, isFailure, response, error) = await marketManagementService.GetMarketCountries(countryRequest, It.IsAny<CancellationToken>());
+            var (_, isFailure, response, error) = await marketManagementService.GetMarketCountries(marketId, It.IsAny<CancellationToken>());
 
             Assert.True(isFailure);
         }

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/BalanceNotificationsTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/BalanceNotificationsTests.cs
@@ -22,6 +22,7 @@ using HappyTravel.Edo.UnitTests.Mocks;
 using HappyTravel.Edo.UnitTests.Utility;
 using HappyTravel.Money.Enums;
 using HappyTravel.Money.Models;
+using HappyTravel.MultiLanguage;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -86,7 +87,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts
                     new Country
                     {
                         Code = "en",
-                        Names = JsonDocument.Parse("{\"en\": \"Russian Federation\"}"),
+                        Names = new MultiLanguage<string> { En = "Russian Federation" },
                         MarketId = 1
                     }
                 }));

--- a/HappyTravel.Edo.UnitTests/Utility/AdministratorServicesMockCreationHelper.cs
+++ b/HappyTravel.Edo.UnitTests/Utility/AdministratorServicesMockCreationHelper.cs
@@ -14,6 +14,7 @@ using HappyTravel.Edo.Data.Markup;
 using HappyTravel.Edo.Data.Payments;
 using HappyTravel.Edo.UnitTests.Mocks;
 using HappyTravel.Money.Enums;
+using HappyTravel.MultiLanguage;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Moq;
 
@@ -40,7 +41,7 @@ namespace HappyTravel.Edo.UnitTests.Utility
         }
 
 
-        public AdminAgencyManagementService GetAgencyManagementService(EdoContext context) 
+        public AdminAgencyManagementService GetAgencyManagementService(EdoContext context)
             => new(context, Mock.Of<IDateTimeProvider>(), Mock.Of<IManagementAuditService>());
 
 
@@ -60,9 +61,9 @@ namespace HappyTravel.Edo.UnitTests.Utility
 
             var agentService = new Api.Services.Agents.AgentService(context, Mock.Of<IDateTimeProvider>());
 
-            return new AgencyVerificationService(context, 
+            return new AgencyVerificationService(context,
                 accountManagementServiceMock.Object,
-                Mock.Of<IManagementAuditService>(), 
+                Mock.Of<IManagementAuditService>(),
                 Mock.Of<INotificationService>(),
                 new DefaultDateTimeProvider(),
                 agentService);
@@ -302,7 +303,14 @@ namespace HappyTravel.Edo.UnitTests.Utility
             new Data.Locations.Country
             {
                 Code = "AF",
-                Names = JsonDocument.Parse("{\"ar\": \"أفغانستان\", \"cn\": \"阿富汗\", \"en\": \"Afghanistan\", \"es\": \"Afganistán\", \"fr\": \"Afghanistan\", \"ru\": \"Афганистан\"}")
+                Names = new MultiLanguage<string>
+                {
+                    Ar = "أفغانستان",
+                    En = "Afghanistan",
+                    Es = "Afganistán",
+                    Fr = "Afghanistan",
+                    Ru = "Афганистан"
+                }
             },
         };
     }


### PR DESCRIPTION
Issue: https://github.com/happy-travel/agent-app-project/issues/1324
Insomnia: Edo -> Admin -> Locations
Tests: code was tested through unit tests and insomnia
Migrations: has one JsonDocument -> Multilanguage in country entity

Bugs: one bugs when requests to locations/markets/{:marketId}/countries GET. Bugs happens in one case with marketId = 2. And Bug was fixed, problem was with the old cash)