### PR TITLE
Destination market's markups logic was added

### DIFF
--- a/Api/AdministratorServices/Locations/IMarketManagementStorage.cs
+++ b/Api/AdministratorServices/Locations/IMarketManagementStorage.cs
@@ -10,7 +10,9 @@ namespace Api.AdministratorServices.Locations
         Task<List<Market>> Get(CancellationToken cancellationToken);
         Task<List<Country>> GetMarketCountries(int marketId, CancellationToken cancellationToken);
         Task<Market?> Get(int marketId, CancellationToken cancellationToken);
+        Task<Market?> Get(string countryCode, CancellationToken cancellationToken);
         Task Refresh(CancellationToken cancellationToken);
         Task RefreshMarketCountries(int marketId, CancellationToken cancellationToken);
+        Task RefreshCountry(Country country, CancellationToken cancellationToken);
     }
 }

--- a/Api/Controllers/AdministratorControllers/AgencyMarkupController.cs
+++ b/Api/Controllers/AdministratorControllers/AgencyMarkupController.cs
@@ -22,8 +22,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         {
             _policyManager = policyManager;
         }
-        
-        
+
+
         /// <summary>
         /// Creates markup policy.
         /// </summary>
@@ -36,14 +36,14 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
         public async Task<IActionResult> SetPolicy([FromRoute] int agencyId, [FromBody] SetAgencyMarkupRequest settings)
         {
-            var (_, isFailure, error) = await _policyManager.SetAgencyPolicy(agencyId, settings);
+            var (_, isFailure, error) = await _policyManager.AddAgencyPolicy(agencyId, settings);
             if (isFailure)
                 return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return NoContent();
         }
-        
-        
+
+
         /// <summary>
         /// Gets markup policies for the agency.
         /// </summary>
@@ -52,7 +52,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         [HttpGet]
         [ProducesResponseType(typeof(List<MarkupInfo>), StatusCodes.Status200OK)]
         [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
-        public async Task<IActionResult> GetChildAgencyPolicies([FromRoute] int agencyId) 
+        public async Task<IActionResult> GetChildAgencyPolicies([FromRoute] int agencyId)
             => Ok(await _policyManager.GetForAgency(agencyId));
 
 
@@ -65,7 +65,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
-        public async Task<IActionResult> RemovePolicy([FromRoute]int agencyId)
+        public async Task<IActionResult> RemovePolicy([FromRoute] int agencyId)
         {
             var (_, isFailure, error) = await _policyManager.RemoveAgencyPolicy(agencyId);
             if (isFailure)
@@ -73,8 +73,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
 
             return NoContent();
         }
-        
-        
+
+
         private readonly IAdminMarkupPolicyManager _policyManager;
     }
 }

--- a/Api/Controllers/AdministratorControllers/GlobalMarkupController.cs
+++ b/Api/Controllers/AdministratorControllers/GlobalMarkupController.cs
@@ -20,8 +20,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         {
             _policyManager = policyManager;
         }
-        
-        
+
+
         /// <summary>
         /// Gets global markup policy
         /// </summary>
@@ -34,8 +34,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         {
             return Ok(await _policyManager.GetGlobalPolicy());
         }
-        
-        
+
+
         /// <summary>
         ///     Deletes global policy.
         /// </summary>
@@ -52,8 +52,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
 
             return NoContent();
         }
-        
-        
+
+
         /// <summary>
         ///     Updates global policy settings.
         /// </summary>
@@ -65,14 +65,14 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
         public async Task<IActionResult> SetPolicy([FromBody] SetGlobalMarkupRequest policySettings)
         {
-            var (_, isFailure, error) = await _policyManager.SetGlobalPolicy(policySettings);
+            var (_, isFailure, error) = await _policyManager.AddGlobalPolicy(policySettings);
             if (isFailure)
                 return BadRequest(ProblemDetailsBuilder.Build(error));
 
             return NoContent();
         }
-        
-        
+
+
         private readonly IAdminMarkupPolicyManager _policyManager;
     }
 }

--- a/Api/Controllers/AdministratorControllers/LocationMarkupsController.cs
+++ b/Api/Controllers/AdministratorControllers/LocationMarkupsController.cs
@@ -66,9 +66,9 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
-        public async Task<IActionResult> UpdatePolicy(int policyId, [FromBody] MarkupPolicySettings policySettings)
+        public async Task<IActionResult> ModifyPolicy(int policyId, [FromBody] MarkupPolicySettings policySettings)
         {
-            var (_, isFailure, error) = await _policyManager.UpdateLocationPolicy(policyId, policySettings);
+            var (_, isFailure, error) = await _policyManager.ModifyLocationPolicy(policyId, policySettings);
             if (isFailure)
                 return BadRequest(ProblemDetailsBuilder.Build(error));
 

--- a/Api/Controllers/AdministratorControllers/LocationMarkupsController.cs
+++ b/Api/Controllers/AdministratorControllers/LocationMarkupsController.cs
@@ -66,9 +66,9 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.MarkupManagement)]
-        public async Task<IActionResult> ModifyPolicy(int policyId, [FromBody] MarkupPolicySettings policySettings)
+        public async Task<IActionResult> UpdatePolicy(int policyId, [FromBody] MarkupPolicySettings policySettings)
         {
-            var (_, isFailure, error) = await _policyManager.ModifyLocationPolicy(policyId, policySettings);
+            var (_, isFailure, error) = await _policyManager.UpdateLocationPolicy(policyId, policySettings);
             if (isFailure)
                 return BadRequest(ProblemDetailsBuilder.Build(error));
 

--- a/Api/HappyTravel.Edo.Api.csproj
+++ b/Api/HappyTravel.Edo.Api.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="HappyTravel.EdoContracts" Version="2.5.2" />
     <PackageReference Include="HappyTravel.ErrorHandling" Version="1.2.3" />
     <PackageReference Include="HappyTravel.MailSender" Version="1.4.0" />
-    <PackageReference Include="HappyTravel.MapperContracts" Version="1.1.5" />
+    <PackageReference Include="HappyTravel.MapperContracts" Version="1.2.0" />
     <PackageReference Include="HappyTravel.StdOutLogger" Version="1.7.0" />
     <PackageReference Include="HappyTravel.SupplierOptionsClient" Version="0.5.2" />
     <PackageReference Include="HappyTravel.SupplierOptionsProvider" Version="0.8.1" />

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -3485,6 +3485,11 @@
                 Destination of booking from the mapper
             </summary>
         </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Markups.MarkupPolicySettings.DestinationScopeType">
+            <summary>
+                Destination type of booking from the mapper
+            </summary>
+        </member>
         <member name="T:HappyTravel.Edo.Api.Models.Payments.AccountBalanceInfo">
             <summary>
                 Account balance info

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -2144,7 +2144,7 @@
             Token to use between 3-rd step and booking to avoid double bookings
             </summary>
         </member>
-        <member name="P:HappyTravel.Edo.Api.Models.Accommodations.RoomContractSetAvailability.RegionId">
+        <member name="P:HappyTravel.Edo.Api.Models.Accommodations.RoomContractSetAvailability.MarketId">
             <summary>
             Country code of accommodation
             </summary>

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -2144,6 +2144,11 @@
             Token to use between 3-rd step and booking to avoid double bookings
             </summary>
         </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Accommodations.RoomContractSetAvailability.RegionId">
+            <summary>
+            Country code of accommodation
+            </summary>
+        </member>
         <member name="P:HappyTravel.Edo.Api.Models.Accommodations.SlimAccommodation.Location">
             <summary>
                 The accommodation location description.

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -585,7 +585,7 @@
             </summary>
             <returns>List of location markups</returns>
         </member>
-        <member name="M:HappyTravel.Edo.Api.Controllers.AdministratorControllers.LocationMarkupsController.UpdatePolicy(System.Int32,HappyTravel.Edo.Api.Models.Markups.MarkupPolicySettings)">
+        <member name="M:HappyTravel.Edo.Api.Controllers.AdministratorControllers.LocationMarkupsController.ModifyPolicy(System.Int32,HappyTravel.Edo.Api.Models.Markups.MarkupPolicySettings)">
             <summary>
                 Updates policy settings.
             </summary>

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -585,7 +585,7 @@
             </summary>
             <returns>List of location markups</returns>
         </member>
-        <member name="M:HappyTravel.Edo.Api.Controllers.AdministratorControllers.LocationMarkupsController.ModifyPolicy(System.Int32,HappyTravel.Edo.Api.Models.Markups.MarkupPolicySettings)">
+        <member name="M:HappyTravel.Edo.Api.Controllers.AdministratorControllers.LocationMarkupsController.UpdatePolicy(System.Int32,HappyTravel.Edo.Api.Models.Markups.MarkupPolicySettings)">
             <summary>
                 Updates policy settings.
             </summary>

--- a/Api/Models/Accommodations/AccommodationAvailabilityResult.cs
+++ b/Api/Models/Accommodations/AccommodationAvailabilityResult.cs
@@ -10,7 +10,7 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         [JsonConstructor]
         public AccommodationAvailabilityResult(Guid searchId, string supplierCode, DateTimeOffset created, string availabilityId,
             List<RoomContractSet> roomContractSets, decimal minPrice, decimal maxPrice, DateTimeOffset checkInDate, DateTimeOffset checkOutDate, string htId, string supplierAccommodationCode, string countryHtId,
-            string localityHtId)
+            string localityHtId, int regionId)
         {
             SearchId = searchId;
             SupplierCode = supplierCode;
@@ -25,8 +25,9 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
             SupplierAccommodationCode = supplierAccommodationCode;
             CountryHtId = countryHtId;
             LocalityHtId = localityHtId;
+            RegionId = regionId;
         }
-        
+
         [JsonIgnore]
         public ObjectId Id { get; init; }
         public Guid SearchId { get; init; }
@@ -42,6 +43,6 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         public string SupplierAccommodationCode { get; init; }
         public string CountryHtId { get; init; }
         public string LocalityHtId { get; init; }
-
+        public int RegionId { get; init; }
     }
 }

--- a/Api/Models/Accommodations/AccommodationAvailabilityResult.cs
+++ b/Api/Models/Accommodations/AccommodationAvailabilityResult.cs
@@ -10,7 +10,7 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         [JsonConstructor]
         public AccommodationAvailabilityResult(Guid searchId, string supplierCode, DateTimeOffset created, string availabilityId,
             List<RoomContractSet> roomContractSets, decimal minPrice, decimal maxPrice, DateTimeOffset checkInDate, DateTimeOffset checkOutDate, string htId, string supplierAccommodationCode, string countryHtId,
-            string localityHtId, int regionId)
+            string localityHtId, int marketId)
         {
             SearchId = searchId;
             SupplierCode = supplierCode;
@@ -25,7 +25,7 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
             SupplierAccommodationCode = supplierAccommodationCode;
             CountryHtId = countryHtId;
             LocalityHtId = localityHtId;
-            RegionId = regionId;
+            MarketId = marketId;
         }
 
         [JsonIgnore]
@@ -43,6 +43,6 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         public string SupplierAccommodationCode { get; init; }
         public string CountryHtId { get; init; }
         public string LocalityHtId { get; init; }
-        public int RegionId { get; init; }
+        public int MarketId { get; init; }
     }
 }

--- a/Api/Models/Accommodations/RoomContractSetAvailability.cs
+++ b/Api/Models/Accommodations/RoomContractSetAvailability.cs
@@ -10,7 +10,7 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         [JsonConstructor]
         public RoomContractSetAvailability(string availabilityId, DateTimeOffset checkInDate, DateTimeOffset checkOutDate, int numberOfNights,
             in SlimAccommodation accommodation, in RoomContractSet roomContractSet, List<PaymentTypes> availablePaymentMethods,
-            string countryHtId, string localityHtId, string evaluationToken, int regionId)
+            string countryHtId, string localityHtId, string evaluationToken, int marketId)
         {
             AvailabilityId = availabilityId;
             CheckInDate = checkInDate;
@@ -22,7 +22,7 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
             CountryHtId = countryHtId;
             LocalityHtId = localityHtId;
             EvaluationToken = evaluationToken;
-            RegionId = regionId;
+            MarketId = marketId;
         }
 
         /// <summary>
@@ -78,6 +78,6 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         /// <summary>
         /// Country code of accommodation
         /// </summary>
-        public int RegionId { get; }
+        public int MarketId { get; }
     }
 }

--- a/Api/Models/Accommodations/RoomContractSetAvailability.cs
+++ b/Api/Models/Accommodations/RoomContractSetAvailability.cs
@@ -9,8 +9,8 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
     {
         [JsonConstructor]
         public RoomContractSetAvailability(string availabilityId, DateTimeOffset checkInDate, DateTimeOffset checkOutDate, int numberOfNights,
-            in SlimAccommodation accommodation, in RoomContractSet roomContractSet, List<PaymentTypes> availablePaymentMethods, 
-            string countryHtId, string localityHtId, string evaluationToken)
+            in SlimAccommodation accommodation, in RoomContractSet roomContractSet, List<PaymentTypes> availablePaymentMethods,
+            string countryHtId, string localityHtId, string evaluationToken, int regionId)
         {
             AvailabilityId = availabilityId;
             CheckInDate = checkInDate;
@@ -22,8 +22,9 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
             CountryHtId = countryHtId;
             LocalityHtId = localityHtId;
             EvaluationToken = evaluationToken;
+            RegionId = regionId;
         }
-        
+
         /// <summary>
         ///     The availability ID.
         /// </summary>
@@ -58,12 +59,12 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         /// List of available payment methods
         /// </summary>
         public List<PaymentTypes> AvailablePaymentMethods { get; }
-        
+
         /// <summary>
         /// Country of accommodation
         /// </summary>
         public string CountryHtId { get; }
-        
+
         /// <summary>
         /// Locality of accommodation
         /// </summary>
@@ -73,5 +74,10 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         /// Token to use between 3-rd step and booking to avoid double bookings
         /// </summary>
         public string EvaluationToken { get; }
+
+        /// <summary>
+        /// Country code of accommodation
+        /// </summary>
+        public int RegionId { get; }
     }
 }

--- a/Api/Models/Accommodations/SingleAccommodationAvailability.cs
+++ b/Api/Models/Accommodations/SingleAccommodationAvailability.cs
@@ -12,7 +12,7 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
             string htId,
             string countryHtId,
             string localityHtId,
-            int regionId)
+            int marketId)
         {
             AvailabilityId = availabilityId;
             CheckInDate = checkInDate;
@@ -20,7 +20,7 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
             RoomContractSets = roomContractSets ?? new List<RoomContractSet>(0);
             CountryHtId = countryHtId;
             LocalityHtId = localityHtId;
-            RegionId = regionId;
+            MarketId = marketId;
         }
 
         public string AvailabilityId { get; }
@@ -34,6 +34,6 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         public string CountryHtId { get; }
 
         public string LocalityHtId { get; }
-        public int RegionId { get; }
+        public int MarketId { get; }
     }
 }

--- a/Api/Models/Accommodations/SingleAccommodationAvailability.cs
+++ b/Api/Models/Accommodations/SingleAccommodationAvailability.cs
@@ -11,7 +11,8 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
             List<RoomContractSet> roomContractSets,
             string htId,
             string countryHtId,
-            string localityHtId)
+            string localityHtId,
+            int regionId)
         {
             AvailabilityId = availabilityId;
             CheckInDate = checkInDate;
@@ -19,6 +20,7 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
             RoomContractSets = roomContractSets ?? new List<RoomContractSet>(0);
             CountryHtId = countryHtId;
             LocalityHtId = localityHtId;
+            RegionId = regionId;
         }
 
         public string AvailabilityId { get; }
@@ -28,9 +30,10 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         public string HtId { get; }
 
         public List<RoomContractSet> RoomContractSets { get; }
-        
+
         public string CountryHtId { get; }
-        
+
         public string LocalityHtId { get; }
+        public int RegionId { get; }
     }
 }

--- a/Api/Models/Availabilities/Mapping/SupplierCodeMapping.cs
+++ b/Api/Models/Availabilities/Mapping/SupplierCodeMapping.cs
@@ -6,6 +6,6 @@ namespace HappyTravel.Edo.Api.Models.Availabilities.Mapping
         public string SupplierCode { get; init; }
         public string LocalityHtId { get; init; }
         public string CountryHtId { get; init; }
-        
+        public int RegionId { get; init; }
     }
 }

--- a/Api/Models/Availabilities/Mapping/SupplierCodeMapping.cs
+++ b/Api/Models/Availabilities/Mapping/SupplierCodeMapping.cs
@@ -6,6 +6,6 @@ namespace HappyTravel.Edo.Api.Models.Availabilities.Mapping
         public string SupplierCode { get; init; }
         public string LocalityHtId { get; init; }
         public string CountryHtId { get; init; }
-        public int RegionId { get; init; }
+        public int MarketId { get; init; }
     }
 }

--- a/Api/Models/Markups/MarkupPolicyScope.cs
+++ b/Api/Models/Markups/MarkupPolicyScope.cs
@@ -55,12 +55,13 @@ namespace HappyTravel.Edo.Api.Models.Markups
             type = Type;
             agentScopeId = Type switch
             {
-                SubjectMarkupScopeTypes.Global => "",
+                SubjectMarkupScopeTypes.Global => string.Empty,
                 SubjectMarkupScopeTypes.Market => LocationId,
                 SubjectMarkupScopeTypes.Country => LocationId,
                 SubjectMarkupScopeTypes.Locality => LocationId,
                 SubjectMarkupScopeTypes.Agency => AgencyId.ToString(),
                 SubjectMarkupScopeTypes.Agent => AgentInAgencyId.Create(AgentId.Value, AgencyId.Value).ToString(),
+                SubjectMarkupScopeTypes.NotSpecified => string.Empty,
                 _ => throw new ArgumentOutOfRangeException(nameof(type), Type, "Wrong AgentMarkupScopeType")
             };
             agencyId = AgencyId;

--- a/Api/Models/Markups/MarkupPolicySettings.cs
+++ b/Api/Models/Markups/MarkupPolicySettings.cs
@@ -9,8 +9,8 @@ namespace HappyTravel.Edo.Api.Models.Markups
     {
         [JsonConstructor]
         public MarkupPolicySettings(string? description, MarkupFunctionType functionType, decimal value,
-            Currencies currency, string locationScopeId, string? destinationScopeId,
-            SubjectMarkupScopeTypes locationScopeType)
+            Currencies currency, string? locationScopeId, string? destinationScopeId,
+            SubjectMarkupScopeTypes? locationScopeType, DestinationMarkupScopeTypes destinationScopeTypes)
         {
             Description = description;
             FunctionType = functionType;
@@ -19,12 +19,13 @@ namespace HappyTravel.Edo.Api.Models.Markups
             LocationScopeId = locationScopeId;
             LocationScopeType = locationScopeType;
             DestinationScopeId = destinationScopeId;
+            DestinationScopeType = destinationScopeTypes;
         }
 
 
         public MarkupPolicySettings(string? description, MarkupFunctionType functionType, decimal value,
-            Currencies currency, string locationScopeId = "", SubjectMarkupScopeTypes locationScopeType = SubjectMarkupScopeTypes.NotSpecified,
-            string? destinationScopeId = null)
+            Currencies currency, string? locationScopeId = "", SubjectMarkupScopeTypes? locationScopeType = SubjectMarkupScopeTypes.NotSpecified,
+            string? destinationScopeId = null, DestinationMarkupScopeTypes? destinationScopeType = DestinationMarkupScopeTypes.NotSpecified)
         {
             Description = description;
             FunctionType = functionType;
@@ -33,6 +34,7 @@ namespace HappyTravel.Edo.Api.Models.Markups
             LocationScopeId = locationScopeId;
             LocationScopeType = locationScopeType;
             DestinationScopeId = destinationScopeId;
+            DestinationScopeType = destinationScopeType;
         }
 
 
@@ -53,18 +55,24 @@ namespace HappyTravel.Edo.Api.Models.Markups
         /// <summary>
         ///     Location of agent from the mapper
         /// </summary>
-        public string LocationScopeId { get; }
+        public string? LocationScopeId { get; }
 
 
         /// <summary>
         ///     Type of location scope of agent from the mapper
         /// </summary>
-        public SubjectMarkupScopeTypes LocationScopeType { get; }
+        public SubjectMarkupScopeTypes? LocationScopeType { get; }
 
 
         /// <summary>
         ///     Destination of booking from the mapper
         /// </summary>
         public string? DestinationScopeId { get; }
+
+
+        /// <summary>
+        ///     Destination type of booking from the mapper
+        /// </summary>
+        public DestinationMarkupScopeTypes? DestinationScopeType { get; }
     }
 }

--- a/Api/Models/Markups/MarkupPolicySettings.cs
+++ b/Api/Models/Markups/MarkupPolicySettings.cs
@@ -10,7 +10,7 @@ namespace HappyTravel.Edo.Api.Models.Markups
         [JsonConstructor]
         public MarkupPolicySettings(string? description, MarkupFunctionType functionType, decimal value,
             Currencies currency, string? locationScopeId, string? destinationScopeId,
-            SubjectMarkupScopeTypes? locationScopeType, DestinationMarkupScopeTypes destinationScopeTypes)
+            SubjectMarkupScopeTypes? locationScopeType, DestinationMarkupScopeTypes? destinationScopeType)
         {
             Description = description;
             FunctionType = functionType;
@@ -19,7 +19,7 @@ namespace HappyTravel.Edo.Api.Models.Markups
             LocationScopeId = locationScopeId;
             LocationScopeType = locationScopeType;
             DestinationScopeId = destinationScopeId;
-            DestinationScopeType = destinationScopeTypes;
+            DestinationScopeType = destinationScopeType;
         }
 
 

--- a/Api/Models/Markups/MarkupPolicySettings.cs
+++ b/Api/Models/Markups/MarkupPolicySettings.cs
@@ -24,8 +24,22 @@ namespace HappyTravel.Edo.Api.Models.Markups
 
 
         public MarkupPolicySettings(string? description, MarkupFunctionType functionType, decimal value,
-            Currencies currency, string? locationScopeId = "", SubjectMarkupScopeTypes? locationScopeType = SubjectMarkupScopeTypes.NotSpecified,
-            string? destinationScopeId = null, DestinationMarkupScopeTypes? destinationScopeType = DestinationMarkupScopeTypes.NotSpecified)
+                Currencies currency, string? locationScopeId)
+        {
+            Description = description;
+            FunctionType = functionType;
+            Value = value;
+            Currency = currency;
+            LocationScopeId = locationScopeId ?? string.Empty;
+            LocationScopeType = SubjectMarkupScopeTypes.NotSpecified;
+            DestinationScopeId = string.Empty;
+            DestinationScopeType = DestinationMarkupScopeTypes.NotSpecified;
+        }
+
+
+        public MarkupPolicySettings(MarkupFunctionType functionType, decimal value,
+            Currencies currency, string description, string locationScopeId, SubjectMarkupScopeTypes locationScopeType,
+            string destinationScopeId, DestinationMarkupScopeTypes destinationScopeType)
         {
             Description = description;
             FunctionType = functionType;

--- a/Api/Services/Accommodations/Availability/Mapping/AvailabilitySearchAreaService.cs
+++ b/Api/Services/Accommodations/Availability/Mapping/AvailabilitySearchAreaService.cs
@@ -54,7 +54,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Mapping
                         SupplierCode = supplierInfo.Value,
                         CountryHtId = location.CountryHtId,
                         LocalityHtId = location.LocalityHtId,
-                        RegionId = _edoContext.Countries
+                        MarketId = _edoContext.Countries
                             .Where(c => c.Code == location.CountryCode)
                             .Select(c => c.MarketId)
                             .FirstOrDefault()

--- a/Api/Services/Accommodations/Availability/Mapping/IAvailabilitySearchAreaService.cs
+++ b/Api/Services/Accommodations/Availability/Mapping/IAvailabilitySearchAreaService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Threading;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Models.Availabilities.Mapping;
 
@@ -7,6 +8,6 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Mapping
 {
     public interface IAvailabilitySearchAreaService
     {
-        Task<Result<SearchArea>> GetSearchArea(List<string> htIds, string languageCode);
+        Task<Result<SearchArea>> GetSearchArea(List<string> htIds, string languageCode, CancellationToken cancellationToken = default);
     }
 }

--- a/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationPolicyProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationPolicyProcessor.cs
@@ -16,7 +16,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 accommodation: availability.Accommodation,
                 countryHtId: availability.CountryHtId,
                 localityHtId: availability.LocalityHtId,
-                evaluationToken: availability.EvaluationToken);
+                evaluationToken: availability.EvaluationToken,
+                regionId: availability.RegionId);
         }
     }
 }

--- a/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationPolicyProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationPolicyProcessor.cs
@@ -17,7 +17,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 countryHtId: availability.CountryHtId,
                 localityHtId: availability.LocalityHtId,
                 evaluationToken: availability.EvaluationToken,
-                regionId: availability.RegionId);
+                marketId: availability.MarketId);
         }
     }
 }

--- a/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationPriceProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationPriceProcessor.cs
@@ -16,13 +16,13 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
         {
             _priceProcessor = priceProcessor;
         }
-        
-        
-        public Task<RoomContractSetAvailability> ApplyMarkups(RoomContractSetAvailability response, AgentContext agent, Action<MarkupApplicationResult<RoomContractSetAvailability>> logAction) 
+
+
+        public Task<RoomContractSetAvailability> ApplyMarkups(RoomContractSetAvailability response, AgentContext agent, Action<MarkupApplicationResult<RoomContractSetAvailability>> logAction)
             => _priceProcessor.ApplyMarkups(agent.ToMarkupSubjectInfo(), response, ProcessPrices, GetMarkupDestinationInfo, logAction);
 
-        
-        public Task<Result<RoomContractSetAvailability, ProblemDetails>> ConvertCurrencies(RoomContractSetAvailability availabilityDetails) 
+
+        public Task<Result<RoomContractSetAvailability, ProblemDetails>> ConvertCurrencies(RoomContractSetAvailability availabilityDetails)
             => _priceProcessor.ConvertCurrencies(availabilityDetails, ProcessPrices, GetCurrency);
 
 
@@ -38,7 +38,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 availablePaymentMethods: value.AvailablePaymentMethods,
                 countryHtId: value.CountryHtId,
                 localityHtId: value.LocalityHtId,
-                evaluationToken: value.EvaluationToken);
+                evaluationToken: value.EvaluationToken,
+                regionId: value.RegionId);
         }
 
 
@@ -55,7 +56,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 availablePaymentMethods: value.AvailablePaymentMethods,
                 countryHtId: value.CountryHtId,
                 localityHtId: value.LocalityHtId,
-                evaluationToken: value.EvaluationToken);
+                evaluationToken: value.EvaluationToken,
+                regionId: value.RegionId);
         }
 
 
@@ -64,7 +66,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
             {
                 AccommodationHtId = availability.Accommodation.HtId,
                 CountryHtId = availability.CountryHtId,
-                LocalityHtId = availability.LocalityHtId
+                LocalityHtId = availability.LocalityHtId,
+                RegionId = availability.RegionId
             };
 
 
@@ -73,7 +76,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 ? null
                 : availabilityDetails.RoomContractSet.Rate.Currency;
 
-        
+
         private readonly IPriceProcessor _priceProcessor;
     }
 }

--- a/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationPriceProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationPriceProcessor.cs
@@ -39,7 +39,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 countryHtId: value.CountryHtId,
                 localityHtId: value.LocalityHtId,
                 evaluationToken: value.EvaluationToken,
-                regionId: value.RegionId);
+                marketId: value.MarketId);
         }
 
 
@@ -57,7 +57,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 countryHtId: value.CountryHtId,
                 localityHtId: value.LocalityHtId,
                 evaluationToken: value.EvaluationToken,
-                regionId: value.RegionId);
+                marketId: value.MarketId);
         }
 
 
@@ -67,7 +67,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 AccommodationHtId = availability.Accommodation.HtId,
                 CountryHtId = availability.CountryHtId,
                 LocalityHtId = availability.LocalityHtId,
-                RegionId = availability.RegionId
+                MarketId = availability.MarketId
             };
 
 

--- a/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationService.cs
+++ b/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationService.cs
@@ -105,7 +105,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 .Map(ApplySearchSettings);
 
 
-            async Task<Result<(string SupplierCode, RoomContractSet RoomContractSet, string AvailabilityId, string htId, string CountryHtId, string LocalityHtId, int RegionId)>>
+            async Task<Result<(string SupplierCode, RoomContractSet RoomContractSet, string AvailabilityId, string htId, string CountryHtId, string LocalityHtId, int MarketId)>>
                 GetSelectedRoomSet(Guid searchId, string htId, Guid roomContractSetId)
             {
                 var result = (await _roomSelectionStorage.GetResult(searchId, htId, settings.EnabledConnectors))
@@ -113,7 +113,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                     {
                         return r.Result.RoomContractSets
                             .Select(rs => (Source: r.SupplierCode, RoomContractSet: rs, r.Result.AvailabilityId, r.Result.HtId,
-                                CountryHtId: r.Result.CountryHtId, LocalityHtId: r.Result.LocalityHtId, r.Result.RegionId));
+                                CountryHtId: r.Result.CountryHtId, LocalityHtId: r.Result.LocalityHtId, r.Result.MarketId));
                     })
                     .SingleOrDefault(r => r.RoomContractSet.Id == roomContractSetId);
 
@@ -148,7 +148,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                     countryHtId: result.CountryHtId,
                     localityHtId: result.LocalityHtId,
                     evaluationToken: evaluationToken,
-                    regionId: result.RegionId);
+                    marketId: result.MarketId);
             }
 
 
@@ -268,7 +268,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                     countryHtId: availability.CountryHtId,
                     localityHtId: availability.LocalityHtId,
                     evaluationToken: availability.EvaluationToken,
-                    regionId: availability.RegionId);
+                    marketId: availability.MarketId);
             }
 
 

--- a/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationService.cs
+++ b/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationService.cs
@@ -53,8 +53,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
             _availabilityRequestStorage = availabilityRequestStorage;
             _supplierOptionsStorage = supplierOptionsStorage;
         }
-        
-        
+
+
         public async Task<Result<RoomContractSetAvailability?, ProblemDetails>> GetExactAvailability(
             Guid searchId, string htId, Guid roomContractSetId, AgentContext agent, string languageCode)
         {
@@ -79,7 +79,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 return (RoomContractSetAvailability?)null;
 
             var originalSupplierPrice = connectorEvaluationResult.Value.Value.RoomContractSet.Rate.FinalPrice;
-            
+
             var (_, isContractFailure, contractKind, contractError) = await _adminAgencyManagementService.GetContractKind(agent.AgencyId);
             if (isContractFailure)
                 return ProblemDetailsBuilder.Fail<RoomContractSetAvailability?>(contractError);
@@ -105,7 +105,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 .Map(ApplySearchSettings);
 
 
-            async Task<Result<(string SupplierCode, RoomContractSet RoomContractSet, string AvailabilityId, string htId, string CountryHtId, string LocalityHtId)>> 
+            async Task<Result<(string SupplierCode, RoomContractSet RoomContractSet, string AvailabilityId, string htId, string CountryHtId, string LocalityHtId, int RegionId)>>
                 GetSelectedRoomSet(Guid searchId, string htId, Guid roomContractSetId)
             {
                 var result = (await _roomSelectionStorage.GetResult(searchId, htId, settings.EnabledConnectors))
@@ -113,26 +113,26 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                     {
                         return r.Result.RoomContractSets
                             .Select(rs => (Source: r.SupplierCode, RoomContractSet: rs, r.Result.AvailabilityId, r.Result.HtId,
-                                CountryHtId: r.Result.CountryHtId, LocalityHtId: r.Result.LocalityHtId));
+                                CountryHtId: r.Result.CountryHtId, LocalityHtId: r.Result.LocalityHtId, r.Result.RegionId));
                     })
                     .SingleOrDefault(r => r.RoomContractSet.Id == roomContractSetId);
 
                 if (result.Equals(default))
-                    return Result.Failure<(string, RoomContractSet, string, string, string, string)>("Could not find selected room contract set");
-                
+                    return Result.Failure<(string, RoomContractSet, string, string, string, string, int)>("Could not find selected room contract set");
+
                 return result;
             }
 
-            
-            Task<Result<EdoContracts.Accommodations.RoomContractSetAvailability?, ProblemDetails>> EvaluateOnConnector((string, RoomContractSet, string, string, string, string) selectedSet)
+
+            Task<Result<EdoContracts.Accommodations.RoomContractSetAvailability?, ProblemDetails>> EvaluateOnConnector((string, RoomContractSet, string, string, string, string, int) selectedSet)
             {
-                var (supplier, roomContractSet, availabilityId, _, _, _) = selectedSet;
+                var (supplier, roomContractSet, availabilityId, _, _, _, _) = selectedSet;
                 return _supplierConnectorManager
                     .Get(supplier)
                     .GetExactAvailability(availabilityId, roomContractSet.Id, languageCode);
             }
 
-            
+
             Result<RoomContractSetAvailability, ProblemDetails> Convert(EdoContracts.Accommodations.RoomContractSetAvailability availabilityData)
             {
                 var (_, isFailure, supplier, error) = _supplierOptionsStorage.Get(result.SupplierCode);
@@ -147,17 +147,18 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                     accommodation: slimAccommodation,
                     countryHtId: result.CountryHtId,
                     localityHtId: result.LocalityHtId,
-                    evaluationToken: evaluationToken);
+                    evaluationToken: evaluationToken,
+                    regionId: result.RegionId);
             }
-            
 
-            Task<Result<RoomContractSetAvailability, ProblemDetails>> ConvertCurrencies(RoomContractSetAvailability availabilityDetails) 
+
+            Task<Result<RoomContractSetAvailability, ProblemDetails>> ConvertCurrencies(RoomContractSetAvailability availabilityDetails)
                 => _priceProcessor.ConvertCurrencies(availabilityDetails);
 
-            
-            RoomContractSetAvailability ProcessPolicies(RoomContractSetAvailability availabilityDetails) 
+
+            RoomContractSetAvailability ProcessPolicies(RoomContractSetAvailability availabilityDetails)
                 => BookingEvaluationPolicyProcessor.Process(availabilityDetails, settings.CancellationPolicyProcessSettings);
-            
+
 
             async Task<DataWithMarkup<RoomContractSetAvailability>> ApplyMarkups(RoomContractSetAvailability response)
             {
@@ -180,14 +181,14 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                             agencyId = int.Parse(policy.SubjectScopeId);
                             break;
                     }
-                    
+
                     appliedMarkups.Add(new AppliedMarkup(
                         scope: new MarkupPolicyScope(policy.SubjectScopeType, agencyId, agentId),
                         policyId: policy.Id,
                         amountChange: markupAmount
                     ));
                 };
-                
+
                 var responseWithMarkups = await _priceProcessor.ApplyMarkups(response, agent, logAction);
                 return DataWithMarkup.Create(responseWithMarkups, appliedMarkups, convertedSupplierPrice, originalSupplierPrice);
             }
@@ -200,9 +201,9 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                     availabilityWithMarkup.AppliedMarkups,
                     availabilityWithMarkup.ConvertedSupplierPrice,
                     originalSupplierPrice);
-            } 
-                
-            
+            }
+
+
             Task SaveToCache(DataWithMarkup<RoomContractSetAvailability> responseWithDeadline)
             {
                 // TODO: Check that this id will not change on all connectors NIJO-823
@@ -214,11 +215,11 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 var agentDeadline = DeadlineMerger.CalculateMergedDeadline(finalRoomContractSet.Rooms);
                 var supplierDeadline = DeadlineMerger.CalculateMergedDeadline(connectorEvaluationResult.Value.Value.RoomContractSet.RoomContracts);
                 var creditCardRequirement = connectorEvaluationResult.Value.Value.CreditCardRequirement;
-                
+
                 return _bookingEvaluationStorage.Set(searchId: searchId,
-                    roomContractSetId: finalRoomContractSet.Id, 
+                    roomContractSetId: finalRoomContractSet.Id,
                     htId: htId,
-                    availability: dataWithMarkup, 
+                    availability: dataWithMarkup,
                     agentDeadline: agentDeadline,
                     supplierDeadline: supplierDeadline,
                     cardRequirement: creditCardRequirement.HasValue
@@ -266,7 +267,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                     availablePaymentMethods: availability.AvailablePaymentMethods,
                     countryHtId: availability.CountryHtId,
                     localityHtId: availability.LocalityHtId,
-                    evaluationToken: availability.EvaluationToken);
+                    evaluationToken: availability.EvaluationToken,
+                    regionId: availability.RegionId);
             }
 
 
@@ -274,8 +276,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 in ContractKind contractKind)
                 => BookingPaymentTypesHelper.GetAvailablePaymentTypes(availability, settings, contractKind, _dateTimeProvider.UtcNow());
         }
-        
-        
+
+
         protected virtual async Task<Result<Accommodation, ProblemDetails>> GetAccommodation(string htId, string languageCode)
         {
             var (_, isFailure, accommodation, problemDetails) = await _accommodationMapperClient.GetAccommodation(htId, languageCode);
@@ -302,8 +304,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 htId: accommodation.HtId,
                 hotelChain: accommodation.HotelChain);
         }
-        
-        
+
+
         private readonly ISupplierConnectorManager _supplierConnectorManager;
         private readonly IBookingEvaluationPriceProcessor _priceProcessor;
         private readonly IRoomSelectionStorage _roomSelectionStorage;

--- a/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/RoomContractSetAvailabilityExtensions.cs
+++ b/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/RoomContractSetAvailabilityExtensions.cs
@@ -8,7 +8,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
     {
         public static RoomContractSetAvailability ToRoomContractSetAvailability(
             this in EdoContracts.Accommodations.RoomContractSetAvailability availabilityValue, string supplier, string supplierCode,
-            List<PaymentTypes> paymentMethods, SlimAccommodation accommodation, string countryHtId, string localityHtId, string evaluationToken, int regionId)
+            List<PaymentTypes> paymentMethods, SlimAccommodation accommodation, string countryHtId, string localityHtId, string evaluationToken, int marketId)
         {
             return new RoomContractSetAvailability(availabilityId: availabilityValue.AvailabilityId,
                 checkInDate: availabilityValue.CheckInDate,
@@ -20,7 +20,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 countryHtId: countryHtId,
                 localityHtId: localityHtId,
                 evaluationToken: evaluationToken,
-                regionId: regionId);
+                marketId: marketId);
         }
     }
 }

--- a/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/RoomContractSetAvailabilityExtensions.cs
+++ b/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/RoomContractSetAvailabilityExtensions.cs
@@ -8,7 +8,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
     {
         public static RoomContractSetAvailability ToRoomContractSetAvailability(
             this in EdoContracts.Accommodations.RoomContractSetAvailability availabilityValue, string supplier, string supplierCode,
-            List<PaymentTypes> paymentMethods, SlimAccommodation accommodation, string countryHtId, string localityHtId, string evaluationToken)
+            List<PaymentTypes> paymentMethods, SlimAccommodation accommodation, string countryHtId, string localityHtId, string evaluationToken, int regionId)
         {
             return new RoomContractSetAvailability(availabilityId: availabilityValue.AvailabilityId,
                 checkInDate: availabilityValue.CheckInDate,
@@ -19,7 +19,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 availablePaymentMethods: paymentMethods,
                 countryHtId: countryHtId,
                 localityHtId: localityHtId,
-                evaluationToken: evaluationToken);
+                evaluationToken: evaluationToken,
+                regionId: regionId);
         }
     }
 }

--- a/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionPolicyProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionPolicyProcessor.cs
@@ -21,7 +21,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                     htId: availability.HtId,
                     countryHtId: availability.CountryHtId,
                     localityHtId: availability.LocalityHtId,
-                    regionId: availability.RegionId);
+                    marketId: availability.MarketId);
         }
     }
 }

--- a/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionPolicyProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionPolicyProcessor.cs
@@ -15,12 +15,13 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
 
 
             static SingleAccommodationAvailability SetRoomContractSets(in SingleAccommodationAvailability availability, List<RoomContractSet> roomContractSets)
-                => new (availabilityId: availability.AvailabilityId,
+                => new(availabilityId: availability.AvailabilityId,
                     checkInDate: availability.CheckInDate,
                     roomContractSets: roomContractSets,
                     htId: availability.HtId,
                     countryHtId: availability.CountryHtId,
-                    localityHtId: availability.LocalityHtId);
+                    localityHtId: availability.LocalityHtId,
+                    regionId: availability.RegionId);
         }
     }
 }

--- a/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionPriceProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionPriceProcessor.cs
@@ -16,8 +16,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
         {
             _priceProcessor = priceProcessor;
         }
-        
-        
+
+
         public async Task<Result<SingleAccommodationAvailability, ProblemDetails>> ConvertCurrencies(SingleAccommodationAvailability availabilityDetails)
         {
             var convertedRoomContractSets = new List<RoomContractSet>(availabilityDetails.RoomContractSets.Count);
@@ -26,10 +26,10 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                 var (_, isFailure, convertedRoomContractSet, error) = await _priceProcessor.ConvertCurrencies(roomContractSet,
                     async (rcs, function) => await RoomContractSetPriceProcessor.ProcessPrices(rcs, function),
                     GetCurrency);
-                    
+
                 if (isFailure)
                     return Result.Failure<SingleAccommodationAvailability, ProblemDetails>(error);
-                    
+
                 convertedRoomContractSets.Add(convertedRoomContractSet);
             }
 
@@ -38,7 +38,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                 roomContractSets: convertedRoomContractSets,
                 htId: availabilityDetails.HtId,
                 countryHtId: availabilityDetails.CountryHtId,
-                localityHtId: availabilityDetails.LocalityHtId);
+                localityHtId: availabilityDetails.LocalityHtId,
+                regionId: availabilityDetails.RegionId);
         }
 
 
@@ -61,7 +62,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                 roomContractSets: convertedRoomContractSets,
                 htId: response.HtId,
                 countryHtId: response.CountryHtId,
-                localityHtId: response.LocalityHtId);
+                localityHtId: response.LocalityHtId,
+                regionId: response.RegionId);
         }
 
 
@@ -73,7 +75,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                 roomContractSets: roomContractSets,
                 htId: source.HtId,
                 countryHtId: source.CountryHtId,
-                localityHtId: source.LocalityHtId);
+                localityHtId: source.LocalityHtId,
+                regionId: source.RegionId);
         }
 
 
@@ -82,7 +85,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
             {
                 AccommodationHtId = availability.HtId,
                 CountryHtId = availability.CountryHtId,
-                LocalityHtId = availability.LocalityHtId
+                LocalityHtId = availability.LocalityHtId,
+                RegionId = availability.RegionId
             };
 
 
@@ -92,8 +96,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                 ? null
                 : roomContractSet.Rate.Currency;
         }
-        
-        
+
+
         private readonly IPriceProcessor _priceProcessor;
     }
 }

--- a/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionPriceProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionPriceProcessor.cs
@@ -39,7 +39,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                 htId: availabilityDetails.HtId,
                 countryHtId: availabilityDetails.CountryHtId,
                 localityHtId: availabilityDetails.LocalityHtId,
-                regionId: availabilityDetails.RegionId);
+                marketId: availabilityDetails.MarketId);
         }
 
 
@@ -63,7 +63,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                 htId: response.HtId,
                 countryHtId: response.CountryHtId,
                 localityHtId: response.LocalityHtId,
-                regionId: response.RegionId);
+                marketId: response.MarketId);
         }
 
 
@@ -76,7 +76,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                 htId: source.HtId,
                 countryHtId: source.CountryHtId,
                 localityHtId: source.LocalityHtId,
-                regionId: source.RegionId);
+                marketId: source.MarketId);
         }
 
 
@@ -86,7 +86,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                 AccommodationHtId = availability.HtId,
                 CountryHtId = availability.CountryHtId,
                 LocalityHtId = availability.LocalityHtId,
-                RegionId = availability.RegionId
+                MarketId = availability.MarketId
             };
 
 

--- a/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionSearchTask.cs
+++ b/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionSearchTask.cs
@@ -36,7 +36,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
 
         public async Task<Result<SingleAccommodationAvailability, ProblemDetails>> GetSupplierAvailability(Guid searchId,
             string htId, string supplierCode, string supplierAccommodationCode, string availabilityId, AccommodationBookingSettings settings,
-            AgentContext agent, string languageCode, string countryHtId, string localityHtId, int regionId)
+            AgentContext agent, string languageCode, string countryHtId, string localityHtId, int marketId)
         {
             return await ExecuteRequest()
                 .Bind(Convert)
@@ -62,7 +62,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                     .ToList();
 
                 return new SingleAccommodationAvailability(availabilityId: availabilityDetails.AvailabilityId, checkInDate: availabilityDetails.CheckInDate,
-                    roomContractSets: roomContractSets, htId: htId, countryHtId: countryHtId, localityHtId: localityHtId, regionId: regionId);
+                    roomContractSets: roomContractSets, htId: htId, countryHtId: countryHtId, localityHtId: localityHtId, marketId: marketId);
             }
 
 

--- a/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionService.cs
+++ b/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionService.cs
@@ -107,7 +107,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                     .Create(scope.ServiceProvider)
                     .GetSupplierAvailability(searchId: searchId, htId: htId, supplierCode: source, supplierAccommodationCode: result.SupplierAccommodationCode,
                         availabilityId: result.AvailabilityId, settings: searchSettings, agent: agent, languageCode: languageCode,
-                        countryHtId: result.CountryHtId, localityHtId: result.LocalityHtId, result.RegionId);
+                        countryHtId: result.CountryHtId, localityHtId: result.LocalityHtId, result.MarketId);
             }
 
 

--- a/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionService.cs
+++ b/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionService.cs
@@ -30,7 +30,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
             IServiceScopeFactory serviceScopeFactory,
             IWideAvailabilitySearchStateStorage stateStorage,
             IBookingAnalyticsService bookingAnalyticsService,
-            IAccommodationMapperClient mapperClient, 
+            IAccommodationMapperClient mapperClient,
             ILogger<RoomSelectionService> logger)
         {
             _accommodationBookingSettingsService = accommodationBookingSettingsService;
@@ -50,8 +50,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
             var results = await _stateStorage.GetStates(searchId, settings.EnabledConnectors);
             return WideAvailabilitySearchState.FromSupplierStates(searchId, results).TaskState;
         }
-        
-        
+
+
         public async Task<Result<AgentAccommodation, ProblemDetails>> GetAccommodation(Guid searchId, string htId, AgentContext agent, string languageCode)
         {
             Baggage.AddSearchId(searchId);
@@ -59,7 +59,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
             var accommodation = await _mapperClient.GetAccommodation(htId, languageCode);
             if (accommodation.IsFailure)
                 return accommodation.Error;
-            
+
             _bookingAnalyticsService.LogAccommodationAvailabilityRequested(accommodation.Value, searchId, htId, agent);
 
             var searchSettings = await _accommodationBookingSettingsService.Get(agent);
@@ -72,7 +72,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
         {
             Baggage.AddSearchId(searchId);
             var searchSettings = await _accommodationBookingSettingsService.Get(agent);
-            
+
             var (_, isFailure, selectedResults, error) = await GetSelectedWideAvailabilityResults(searchId, htId, agent);
             if (isFailure)
                 return Result.Failure<List<RoomContractSet>>(error);
@@ -105,11 +105,11 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
 
                 return await RoomSelectionSearchTask
                     .Create(scope.ServiceProvider)
-                    .GetSupplierAvailability(searchId: searchId, htId: htId, supplierCode: source, supplierAccommodationCode: result.SupplierAccommodationCode, 
+                    .GetSupplierAvailability(searchId: searchId, htId: htId, supplierCode: source, supplierAccommodationCode: result.SupplierAccommodationCode,
                         availabilityId: result.AvailabilityId, settings: searchSettings, agent: agent, languageCode: languageCode,
-                        countryHtId: result.CountryHtId, localityHtId: result.LocalityHtId);
+                        countryHtId: result.CountryHtId, localityHtId: result.LocalityHtId, result.RegionId);
             }
-            
+
 
             async Task<Result<List<(string Source, AccommodationAvailabilityResult Result)>>> GetSelectedWideAvailabilityResults(Guid searchId, string htId, AgentContext agent)
             {
@@ -123,7 +123,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                 return results.ToList();
             }
 
-            
+
             IEnumerable<RoomContractSet> MapToRoomContractSets(SingleAccommodationAvailability accommodationAvailability)
             {
                 return accommodationAvailability.RoomContractSets
@@ -131,7 +131,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
             }
 
 
-            bool SettingsFilter(RoomContractSet roomSet) 
+            bool SettingsFilter(RoomContractSet roomSet)
                 => RoomContractSetSettingsChecker.IsDisplayAllowed(roomSet, checkInDate, searchSettings, _dateTimeProvider);
         }
 

--- a/Api/Services/Accommodations/Availability/Steps/WideAvailabilitySearch/WideAvailabilityPriceProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/WideAvailabilitySearch/WideAvailabilityPriceProcessor.cs
@@ -17,8 +17,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
         {
             _priceProcessor = priceProcessor;
         }
-        
-        
+
+
         public async Task<List<AccommodationAvailabilityResult>> ApplyMarkups(List<AccommodationAvailabilityResult> results, AgentContext agent)
         {
             var convertedResults = new List<AccommodationAvailabilityResult>(results.Count);
@@ -32,10 +32,10 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                         roomContractSet,
                         async (rcs, function) => await RoomContractSetPriceProcessor.ProcessPrices(rcs, function),
                         _ => GetMarkupDestinationInfo(slimAccommodationAvailability));
-                    
+
                     convertedRoomContractSets.Add(convertedRoomContractSet);
                 }
-                
+
                 convertedResults.Add(new AccommodationAvailabilityResult(searchId: slimAccommodationAvailability.SearchId,
                     supplierCode: slimAccommodationAvailability.SupplierCode,
                     created: slimAccommodationAvailability.Created,
@@ -48,7 +48,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                     htId: slimAccommodationAvailability.HtId,
                     supplierAccommodationCode: slimAccommodationAvailability.SupplierAccommodationCode,
                     countryHtId: slimAccommodationAvailability.CountryHtId,
-                    localityHtId: slimAccommodationAvailability.LocalityHtId));
+                    localityHtId: slimAccommodationAvailability.LocalityHtId,
+                    regionId: slimAccommodationAvailability.RegionId));
             }
 
             return convertedResults;
@@ -66,10 +67,10 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                     var (_, isFailure, convertedRoomContractSet, error) = await _priceProcessor.ConvertCurrencies(roomContractSet,
                         async (rcs, function) => await RoomContractSetPriceProcessor.ProcessPrices(rcs, function),
                         GetCurrency);
-                    
+
                     if (isFailure)
                         return Result.Failure<List<AccommodationAvailabilityResult>, ProblemDetails>(error);
-                    
+
                     convertedRoomContractSets.Add(convertedRoomContractSet);
                 }
 
@@ -85,13 +86,14 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                     htId: slimAccommodationAvailability.HtId,
                     supplierAccommodationCode: slimAccommodationAvailability.SupplierAccommodationCode,
                     countryHtId: slimAccommodationAvailability.CountryHtId,
-                    localityHtId: slimAccommodationAvailability.LocalityHtId));
+                    localityHtId: slimAccommodationAvailability.LocalityHtId,
+                    regionId: slimAccommodationAvailability.RegionId));
             }
 
             return convertedResults;
         }
-        
-        
+
+
         public List<AccommodationAvailabilityResult> AlignPrices(List<AccommodationAvailabilityResult> results)
         {
             var convertedResults = new List<AccommodationAvailabilityResult>(results.Count);
@@ -111,13 +113,14 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                     htId: accommodationAvailability.HtId,
                     supplierAccommodationCode: accommodationAvailability.SupplierAccommodationCode,
                     countryHtId: accommodationAvailability.CountryHtId,
-                    localityHtId: accommodationAvailability.LocalityHtId));
+                    localityHtId: accommodationAvailability.LocalityHtId,
+                    regionId: accommodationAvailability.RegionId));
             }
 
             return convertedResults;
         }
-        
-        
+
+
         private static Currencies? GetCurrency(RoomContractSet roomContractSet)
         {
             return roomContractSet.Rate.Currency == Currencies.NotSpecified
@@ -127,11 +130,12 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
 
 
         private static MarkupDestinationInfo GetMarkupDestinationInfo(AccommodationAvailabilityResult availability)
-            => new ()
+            => new()
             {
                 CountryHtId = availability.CountryHtId,
                 LocalityHtId = availability.LocalityHtId,
-                AccommodationHtId = availability.HtId
+                AccommodationHtId = availability.HtId,
+                RegionId = availability.RegionId
             };
 
 

--- a/Api/Services/Accommodations/Availability/Steps/WideAvailabilitySearch/WideAvailabilityPriceProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/WideAvailabilitySearch/WideAvailabilityPriceProcessor.cs
@@ -49,7 +49,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                     supplierAccommodationCode: slimAccommodationAvailability.SupplierAccommodationCode,
                     countryHtId: slimAccommodationAvailability.CountryHtId,
                     localityHtId: slimAccommodationAvailability.LocalityHtId,
-                    regionId: slimAccommodationAvailability.RegionId));
+                    marketId: slimAccommodationAvailability.MarketId));
             }
 
             return convertedResults;
@@ -87,7 +87,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                     supplierAccommodationCode: slimAccommodationAvailability.SupplierAccommodationCode,
                     countryHtId: slimAccommodationAvailability.CountryHtId,
                     localityHtId: slimAccommodationAvailability.LocalityHtId,
-                    regionId: slimAccommodationAvailability.RegionId));
+                    marketId: slimAccommodationAvailability.MarketId));
             }
 
             return convertedResults;
@@ -114,7 +114,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                     supplierAccommodationCode: accommodationAvailability.SupplierAccommodationCode,
                     countryHtId: accommodationAvailability.CountryHtId,
                     localityHtId: accommodationAvailability.LocalityHtId,
-                    regionId: accommodationAvailability.RegionId));
+                    marketId: accommodationAvailability.MarketId));
             }
 
             return convertedResults;
@@ -135,7 +135,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                 CountryHtId = availability.CountryHtId,
                 LocalityHtId = availability.LocalityHtId,
                 AccommodationHtId = availability.HtId,
-                RegionId = availability.RegionId
+                MarketId = availability.MarketId
             };
 
 

--- a/Api/Services/Accommodations/Availability/Steps/WideAvailabilitySearch/WideAvailabilitySearchTask.cs
+++ b/Api/Services/Accommodations/Availability/Steps/WideAvailabilitySearch/WideAvailabilitySearchTask.cs
@@ -96,7 +96,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
             List<AccommodationAvailabilityResult> Convert(EdoContracts.Accommodations.Availability details)
             {
                 var htIdMapping = accommodationCodeMappings
-                    .ToDictionary(m => m.SupplierCode, m => (m.AccommodationHtId, m.CountryHtId, m.LocalityHtId, m.RegionId));
+                    .ToDictionary(m => m.SupplierCode, m => (m.AccommodationHtId, m.CountryHtId, m.LocalityHtId, m.MarketId));
 
                 var now = _dateTimeProvider.UtcNow();
                 return details
@@ -127,7 +127,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                             supplierAccommodationCode: accommodationAvailability.AccommodationId,
                             countryHtId: htId.CountryHtId,
                             localityHtId: htId.LocalityHtId,
-                            regionId: htId.RegionId);
+                            marketId: htId.MarketId);
                     })
                     .Where(a => !a.Equals(default) && a.RoomContractSets.Any())
                     .ToList();

--- a/Api/Services/Markups/Abstractions/MarkupDestinationInfo.cs
+++ b/Api/Services/Markups/Abstractions/MarkupDestinationInfo.cs
@@ -5,5 +5,6 @@ namespace HappyTravel.Edo.Api.Services.Markups.Abstractions
         public string CountryHtId { get; init; }
         public string LocalityHtId { get; init; }
         public string AccommodationHtId { get; init; }
+        public int RegionId { get; init; }
     }
 }

--- a/Api/Services/Markups/Abstractions/MarkupDestinationInfo.cs
+++ b/Api/Services/Markups/Abstractions/MarkupDestinationInfo.cs
@@ -5,6 +5,6 @@ namespace HappyTravel.Edo.Api.Services.Markups.Abstractions
         public string CountryHtId { get; init; }
         public string LocalityHtId { get; init; }
         public string AccommodationHtId { get; init; }
-        public int RegionId { get; init; }
+        public int MarketId { get; init; }
     }
 }

--- a/Api/Services/Markups/AdminMarkupPolicyManager.cs
+++ b/Api/Services/Markups/AdminMarkupPolicyManager.cs
@@ -217,9 +217,9 @@ namespace HappyTravel.Edo.Api.Services.Markups
         private async Task<Result<SubjectMarkupScopeTypes>> GetAgentMarkupScopeType(MarkupPolicySettings settings)
         {
             if (settings.LocationScopeType == SubjectMarkupScopeTypes.Market)
-                return settings.LocationScopeType;
+                return settings.LocationScopeType.Value;
 
-            var (_, isFailure, value, error) = await _mapperClient.GetSlimLocationDescription(settings.LocationScopeId);
+            var (_, isFailure, value, error) = await _mapperClient.GetSlimLocationDescription(settings.LocationScopeId!);
             if (isFailure)
                 return Result.Failure<SubjectMarkupScopeTypes>(error.Detail);
 

--- a/Api/Services/Markups/AdminMarkupPolicyManager.cs
+++ b/Api/Services/Markups/AdminMarkupPolicyManager.cs
@@ -168,12 +168,12 @@ namespace HappyTravel.Edo.Api.Services.Markups
         }
 
 
-        public async Task<Result> UpdateLocationPolicy(int policyId, MarkupPolicySettings settings)
+        public async Task<Result> ModifyLocationPolicy(int policyId, MarkupPolicySettings settings)
         {
             var policy = await _context.MarkupPolicies
                 .FirstOrDefaultAsync(p => p.Id == policyId);
 
-            return await ValidateUpdateLocation((settings, policy))
+            return await ValidateModifyLocation((settings, policy))
                 .Tap(UpdatePolicy);
 
 
@@ -181,7 +181,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
                 => await Update(policyId, settings);
 
 
-            Result ValidateUpdateLocation((MarkupPolicySettings settings, MarkupPolicy? policy) entity)
+            Result ValidateModifyLocation((MarkupPolicySettings settings, MarkupPolicy? policy) entity)
                 => GenericValidator<(MarkupPolicySettings settings, MarkupPolicy? policy)>.Validate(v =>
                     {
                         v.RuleFor(t => t.policy)

--- a/Api/Services/Markups/IAdminMarkupPolicyManager.cs
+++ b/Api/Services/Markups/IAdminMarkupPolicyManager.cs
@@ -21,7 +21,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
 
         Task<Result> RemoveLocationPolicy(int policyId);
 
-        Task<Result> UpdateLocationPolicy(int policyId, MarkupPolicySettings settings);
+        Task<Result> ModifyLocationPolicy(int policyId, MarkupPolicySettings settings);
 
         Task<Result> AddAgencyPolicy(int agencyId, SetAgencyMarkupRequest request);
 

--- a/Api/Services/Markups/IAdminMarkupPolicyManager.cs
+++ b/Api/Services/Markups/IAdminMarkupPolicyManager.cs
@@ -13,17 +13,17 @@ namespace HappyTravel.Edo.Api.Services.Markups
 
         Task<Result> RemoveGlobalPolicy();
 
-        Task<Result> SetGlobalPolicy(SetGlobalMarkupRequest settings);
+        Task<Result> AddGlobalPolicy(SetGlobalMarkupRequest settings);
 
         Task<List<MarkupInfo>> GetLocationPolicies();
 
         Task<Result> AddLocationPolicy(MarkupPolicySettings settings);
-       
+
         Task<Result> RemoveLocationPolicy(int policyId);
 
-        Task<Result> ModifyLocationPolicy(int policyId, MarkupPolicySettings settings);
+        Task<Result> UpdateLocationPolicy(int policyId, MarkupPolicySettings settings);
 
-        Task<Result> SetAgencyPolicy(int agencyId, SetAgencyMarkupRequest request);
+        Task<Result> AddAgencyPolicy(int agencyId, SetAgencyMarkupRequest request);
 
         Task<AgencyMarkupInfo?> GetForAgency(int agencyId);
 

--- a/Api/Services/Markups/MarkupPolicyExtensions.cs
+++ b/Api/Services/Markups/MarkupPolicyExtensions.cs
@@ -13,12 +13,14 @@ namespace HappyTravel.Edo.Api.Services.Markups
                 ? policy.SubjectScopeId
                 : null;
 
-            return new(description: policy.Description,
-                functionType: policy.FunctionType,
-                value: policy.Value,
-                currency: policy.Currency,
-                locationScopeId: locationScopeId!,
-                destinationScopeId: policy.DestinationScopeId);
+            return new MarkupPolicySettings(policy.FunctionType,
+                policy.Value,
+                policy.Currency,
+                policy.Description ?? string.Empty,
+                locationScopeId ?? string.Empty,
+                policy.SubjectScopeType,
+                policy.DestinationScopeId ?? string.Empty,
+                policy.DestinationScopeType);
         }
     }
 }

--- a/Api/Services/Markups/MarkupPolicyService.cs
+++ b/Api/Services/Markups/MarkupPolicyService.cs
@@ -50,7 +50,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
             static bool IsApplicableByObject(MarkupPolicy policy, MarkupDestinationInfo info)
             {
                 var destinationScopeId = policy.DestinationScopeId;
-                return string.IsNullOrWhiteSpace(destinationScopeId) || destinationScopeId == info.RegionId.ToString();
+                return string.IsNullOrWhiteSpace(destinationScopeId) || destinationScopeId == info.MarketId.ToString();
                 /*|| destinationScopeId == info.CountryHtId || destinationScopeId == info.LocalityHtId || destinationScopeId == info.AccommodationHtId;*/
             }
         }

--- a/Api/Services/Markups/MarkupPolicyService.cs
+++ b/Api/Services/Markups/MarkupPolicyService.cs
@@ -50,8 +50,8 @@ namespace HappyTravel.Edo.Api.Services.Markups
             static bool IsApplicableByObject(MarkupPolicy policy, MarkupDestinationInfo info)
             {
                 var destinationScopeId = policy.DestinationScopeId;
-                return string.IsNullOrWhiteSpace(destinationScopeId); /*|| destinationScopeId == info.CountryHtId
-                    || destinationScopeId == info.LocalityHtId || destinationScopeId == info.AccommodationHtId;*/
+                return string.IsNullOrWhiteSpace(destinationScopeId) || destinationScopeId == info.RegionId.ToString();
+                /*|| destinationScopeId == info.CountryHtId || destinationScopeId == info.LocalityHtId || destinationScopeId == info.AccommodationHtId;*/
             }
         }
 

--- a/HappyTravel.Edo.Common/Enums/Markup/DestinationMarkupScopeTypes.cs
+++ b/HappyTravel.Edo.Common/Enums/Markup/DestinationMarkupScopeTypes.cs
@@ -10,6 +10,7 @@ namespace HappyTravel.Edo.Common.Enums.Markup
         Global = 1,
         Country = 2,
         Locality = 3,
-        Accommodation = 4
+        Accommodation = 4,
+        Market = 5
     }
 }

--- a/HappyTravel.Edo.Data/HappyTravel.Edo.Data.csproj
+++ b/HappyTravel.Edo.Data/HappyTravel.Edo.Data.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="HappyTravel.MapperContracts" Version="1.1.5" />
+    <PackageReference Include="HappyTravel.MapperContracts" Version="1.2.0" />
     <PackageReference Include="HappyTravel.EdoContracts" Version="2.5.2" />
     <PackageReference Include="HappyTravel.VaultClient" Version="1.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.3" />

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/FilterByMarkupDestination.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/FilterByMarkupDestination.cs
@@ -128,14 +128,54 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupPolicyServiceTe
         // }
 
 
-        // private MarkupSubjectInfo GetDummyMarkupSubject()
-        //     => new()
-        //     {
-        //         AgencyAncestors = new List<int>(),
-        //         AgencyId = 1,
-        //         AgentId = 1,
-        //         CountryHtId = "Russia",
-        //         LocalityHtId = "Moscow"
-        //     };
+        [Fact]
+        public void Markups_for_hotel_market_should_be_returned()
+        {
+            var markupSubject = GetDummyMarkupSubject();
+
+            var markupDestination = new MarkupDestinationInfo
+            {
+                AccommodationHtId = "President Hotel",
+                CountryHtId = "UAE",
+                LocalityHtId = "Dubai",
+                MarketId = 2
+            };
+
+            var markupPolicies = new List<MarkupPolicy>
+            {
+                new()
+                {
+                    Id = 1,
+                    SubjectScopeType = SubjectMarkupScopeTypes.Global,
+                    DestinationScopeType = DestinationMarkupScopeTypes.Market,
+                    DestinationScopeId = "2"
+                },
+                new()
+                {
+                    Id = 2,
+                    SubjectScopeType = SubjectMarkupScopeTypes.Global,
+                    DestinationScopeType = DestinationMarkupScopeTypes.Market,
+                    DestinationScopeId = "1"
+                }
+            };
+
+            var service = MarkupPolicyServiceMock.Create(markupPolicies);
+
+            var policies = service.Get(markupSubject, markupDestination);
+
+            Assert.Single(policies);
+            Assert.Equal(1, policies[0].Id);
+        }
+
+
+        private MarkupSubjectInfo GetDummyMarkupSubject()
+            => new()
+            {
+                AgencyAncestors = new List<int>(),
+                AgencyId = 1,
+                AgentId = 1,
+                CountryHtId = "Russia",
+                LocalityHtId = "Moscow"
+            };
     }
 }


### PR DESCRIPTION
Issue: https://github.com/happy-travel/agent-app-project/issues/1290
Tested through insomnia and debug
Insomnia: Edo -> Admin -> Locations

Destination market markup defines by regionId if it equal to destinationScopeId. RegionId was determined by CountryCode which takes from mapper.