### PR TITLE
Feature/aa 1351 remove market id from agencies

### DIFF
--- a/Api/Services/Agents/HttpBasedAgentContextService.cs
+++ b/Api/Services/Agents/HttpBasedAgentContextService.cs
@@ -132,6 +132,7 @@ namespace HappyTravel.Edo.Api.Services.Agents
             return await (from agent in _context.Agents
                     from agentAgencyRelation in _context.AgentAgencyRelations.Where(r => r.AgentId == agent.Id)
                     from agency in _context.Agencies.Where(a => a.Id == agentAgencyRelation.AgencyId && a.IsActive)
+                    from country in _context.Countries.Where(c => c.Code == agency.CountryCode)
                     where agentAgencyRelation.IsActive && agent.IdentityHash == identityHash
                     select new AgentContext(agent.Id,
                         agent.FirstName,
@@ -145,7 +146,7 @@ namespace HappyTravel.Edo.Api.Services.Agents
                         inAgencyPermissions,
                         agency.CountryHtId,
                         agency.LocalityHtId,
-                        agency.MarketId,
+                        country.MarketId,
                         agency.Ancestors))
                 .SingleOrDefaultAsync();
         }
@@ -159,6 +160,7 @@ namespace HappyTravel.Edo.Api.Services.Agents
                     from agentAgencyRelation in _context.AgentAgencyRelations.Where(r => r.AgentId == agent.Id)
                     from apiClient in _context.ApiClients.Where(a => a.Name == name && a.PasswordHash == passwordHash)
                     from agency in _context.Agencies.Where(a => a.Id == agentAgencyRelation.AgencyId && a.IsActive)
+                    from country in _context.Countries.Where(c => c.Code == agency.CountryCode)
                     where agentAgencyRelation.IsActive && agent.Id == apiClient.AgentId && agency.Id == apiClient.AgencyId
                     select new AgentContext(agent.Id,
                         agent.FirstName,
@@ -172,7 +174,7 @@ namespace HappyTravel.Edo.Api.Services.Agents
                         inAgencyPermissions,
                         agency.CountryHtId,
                         agency.LocalityHtId,
-                        agency.MarketId,
+                        country.MarketId,
                         agency.Ancestors))
                 .SingleOrDefaultAsync();
         }

--- a/HappyTravel.Edo.Data/Agents/Agency.cs
+++ b/HappyTravel.Edo.Data/Agents/Agency.cs
@@ -27,7 +27,6 @@ namespace HappyTravel.Edo.Data.Agents
         public List<int> Ancestors { get; set; } = new();
         public string? CountryHtId { get; set; }
         public string? LocalityHtId { get; set; }
-        public int MarketId { get; set; }
         public ContractKind? ContractKind { get; set; }
         public string? VerificationReason { get; set; }
         public AgencyVerificationStates VerificationState { get; set; }

--- a/HappyTravel.Edo.Data/EdoContext.cs
+++ b/HappyTravel.Edo.Data/EdoContext.cs
@@ -300,7 +300,6 @@ namespace HappyTravel.Edo.Data
                     .HasDefaultValue(true);
                 agency.HasIndex(a => a.Ancestors)
                     .HasMethod("gin");
-                agency.Property(a => a.MarketId).IsRequired();
                 agency.Property(a => a.Address).IsRequired();
                 agency.Property(a => a.City).IsRequired();
                 agency.Property(a => a.CountryCode).IsRequired();

--- a/HappyTravel.Edo.Data/Migrations/20220414072117_RemoveMarketIdFromAgenciesEntity.Designer.cs
+++ b/HappyTravel.Edo.Data/Migrations/20220414072117_RemoveMarketIdFromAgenciesEntity.Designer.cs
@@ -8,6 +8,7 @@ using HappyTravel.Edo.Data.Bookings;
 using HappyTravel.MultiLanguage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -16,9 +17,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HappyTravel.Edo.Data.Migrations
 {
     [DbContext(typeof(EdoContext))]
-    partial class EdoContextModelSnapshot : ModelSnapshot
+    [Migration("20220414072117_RemoveMarketIdFromAgenciesEntity")]
+    partial class RemoveMarketIdFromAgenciesEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HappyTravel.Edo.Data/Migrations/20220414072117_RemoveMarketIdFromAgenciesEntity.cs
+++ b/HappyTravel.Edo.Data/Migrations/20220414072117_RemoveMarketIdFromAgenciesEntity.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HappyTravel.Edo.Data.Migrations
+{
+    public partial class RemoveMarketIdFromAgenciesEntity : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MarketId",
+                table: "Agencies");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MarketId",
+                table: "Agencies",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+    }
+}

--- a/HappyTravel.Edo.DirectApi/Services/Overriden/AgentContextService.cs
+++ b/HappyTravel.Edo.DirectApi/Services/Overriden/AgentContextService.cs
@@ -45,6 +45,7 @@ namespace HappyTravel.Edo.DirectApi.Services.Overriden
                     from agentDirectApiRelation in _context.AgentDirectApiClientRelations.Where(a => a.AgentId == agentAgencyRelation.AgentId
                         && a.AgencyId == agentAgencyRelation.AgencyId && a.DirectApiClientId == clientId)
                     from agency in _context.Agencies.Where(a => a.Id == agentAgencyRelation.AgencyId && a.IsActive)
+                    from country in _context.Countries.Where(c => c.Code == agency.CountryCode)
                     select new {
                         AgentId = agent.Id,
                         FirstName = agent.FirstName,
@@ -58,7 +59,7 @@ namespace HappyTravel.Edo.DirectApi.Services.Overriden
                         agentAgencyRelation.AgentRoleIds,
                         CountryHtId = agency.CountryHtId,
                         LocalityHtId = agency.LocalityHtId,
-                        MarketId = agency.MarketId,
+                        MarketId = country.MarketId,
                         AgencyAncestors = agency.Ancestors
                     })
                 .SingleOrDefaultAsync();


### PR DESCRIPTION
Issue: https://github.com/happy-travel/agent-app-project/issues/1351
Insomnia: Edo -> Admin -> Markups -> Location Markups

MarketId was removed from Agency table through migration. Code will be merged after Task #1290.