### PR TITLE
Feature/aa 1291 add agency destination markups

### DIFF
--- a/Api/Services/Markups/AdminMarkupPolicyManager.cs
+++ b/Api/Services/Markups/AdminMarkupPolicyManager.cs
@@ -112,7 +112,9 @@ namespace HappyTravel.Edo.Api.Services.Markups
             async Task<Result> AddPolicy()
                 => await Add(new MarkupPolicyData(settings,
                     new MarkupPolicyScope(settings.LocationScopeType ?? SubjectMarkupScopeTypes.Global,
-                        locationId: settings.LocationScopeId ?? string.Empty)));
+                        locationId: settings.LocationScopeId ?? string.Empty,
+                        agencyId: (settings.LocationScopeType == SubjectMarkupScopeTypes.Agency) ?
+                            int.Parse(settings.LocationScopeId!) : 0)));
 
 
             Result ValidateAddLocation(MarkupPolicySettings settings)
@@ -131,7 +133,8 @@ namespace HappyTravel.Edo.Api.Services.Markups
                             v.RuleFor(m => m.DestinationScopeId)
                                 .NotNull()
                                 .MustAsync(MarketMarkupIsNotExist()!)
-                                .When(m => m.DestinationScopeType == DestinationMarkupScopeTypes.Market)
+                                .When(m => m.DestinationScopeType == DestinationMarkupScopeTypes.Market &&
+                                    m.LocationScopeType is null)
                                 .WithMessage(m => $"Destination markup policy with DestinationScopeId {m.DestinationScopeId} already exists or unexpected value!"); ;
 
                             v.RuleFor(m => m.DestinationScopeType)
@@ -143,6 +146,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
                             v.RuleFor(m => m.LocationScopeId)
                                 .NotNull()
                                 .MustAsync(AgencyIsExist()!)
+                                .WithMessage(m => $"Agency with Id {m.LocationScopeId} doesn't exist!")
                                 .When(m => m.LocationScopeType == SubjectMarkupScopeTypes.Agency);
                         }).Otherwise(() =>
                         {

--- a/Api/Services/Markups/MarkupPolicyExtensions.cs
+++ b/Api/Services/Markups/MarkupPolicyExtensions.cs
@@ -9,15 +9,16 @@ namespace HappyTravel.Edo.Api.Services.Markups
         public static MarkupPolicySettings GetSettings(this MarkupPolicy policy)
         {
             // TODO Cleanup the model: https://github.com/happy-travel/agent-app-project/issues/777
-            var locationScopeId = policy.SubjectScopeType == SubjectMarkupScopeTypes.Market || policy.SubjectScopeType == SubjectMarkupScopeTypes.Country || policy.SubjectScopeType == SubjectMarkupScopeTypes.Locality
-                ? policy.SubjectScopeId
-                : null;
+            // Commented for until markups step 2
+            // var locationScopeId = policy.SubjectScopeType == SubjectMarkupScopeTypes.Market || policy.SubjectScopeType == SubjectMarkupScopeTypes.Country || policy.SubjectScopeType == SubjectMarkupScopeTypes.Locality
+            //     ? policy.SubjectScopeId
+            //     : null;
 
             return new MarkupPolicySettings(policy.FunctionType,
                 policy.Value,
                 policy.Currency,
                 policy.Description ?? string.Empty,
-                locationScopeId ?? string.Empty,
+                policy.SubjectScopeId ?? string.Empty,
                 policy.SubjectScopeType,
                 policy.DestinationScopeId ?? string.Empty,
                 policy.DestinationScopeType);

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/AdminMarkupPolicyTests/AdminMarkupPolicyManagerTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/AdminMarkupPolicyTests/AdminMarkupPolicyManagerTests.cs
@@ -1,0 +1,394 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Infrastructure;
+using HappyTravel.Edo.Api.Models.Markups;
+using HappyTravel.Edo.Api.Models.Users;
+using HappyTravel.Edo.Api.Services.Management;
+using HappyTravel.Edo.Api.Services.Markups;
+using HappyTravel.Edo.Common.Enums;
+using HappyTravel.Edo.Common.Enums.Administrators;
+using HappyTravel.Edo.Common.Enums.Markup;
+using HappyTravel.Edo.Data;
+using HappyTravel.Edo.Data.Agents;
+using HappyTravel.Edo.Data.Locations;
+using HappyTravel.Edo.Data.Management;
+using HappyTravel.Edo.Data.Markup;
+using HappyTravel.Edo.UnitTests.Mocks;
+using HappyTravel.Edo.UnitTests.Utility;
+using HappyTravel.Money.Enums;
+using HappyTravel.MultiLanguage;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Moq;
+using Xunit;
+
+namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.AdminMarkupPolicyTests
+{
+    public class AdminMarkupPolicyManagerTests
+    {
+        public AdminMarkupPolicyManagerTests()
+        {
+            _edoContextMock = MockEdoContextFactory.Create();
+            SetupInitialData();
+
+            var tokenInfoAccessorMock = new Mock<ITokenInfoAccessor>();
+            tokenInfoAccessorMock.Setup(x => x.GetIdentity())
+                .Returns("hash");
+
+            var administratorContext = new HttpBasedAdministratorContext(_edoContextMock.Object, tokenInfoAccessorMock.Object);
+            var auditServiceMock = new Mock<IMarkupPolicyAuditService>();
+            auditServiceMock.Setup(a => a.Write<It.IsAnyType>(It.IsAny<MarkupPolicyEventType>(), It.IsAny<It.IsAnyType>(), It.IsAny<ApiCaller>()))
+                .Returns(Task.CompletedTask);
+
+
+            _adminMarkupPolicyManager = new AdminMarkupPolicyManager(_edoContextMock.Object,
+                Mock.Of<IDateTimeProvider>(), Mock.Of<IDisplayedMarkupFormulaService>(),
+                administratorContext, auditServiceMock.Object);
+
+            var strategy = new ExecutionStrategyMock();
+
+            var dbFacade = new Mock<DatabaseFacade>(_edoContextMock.Object);
+            dbFacade.Setup(d => d.CreateExecutionStrategy()).Returns(strategy);
+            _edoContextMock.Setup(c => c.Database).Returns(dbFacade.Object);
+        }
+
+
+        [Fact]
+        public async Task Add_location_markup_with_destinaion_data_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, 2, Currencies.USD,
+                "2", "Country_12512", SubjectMarkupScopeTypes.Market, DestinationMarkupScopeTypes.Country);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Add_location_or_destination_markup_with_wrong_value_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, 0, Currencies.USD,
+                null, "4", null, DestinationMarkupScopeTypes.Market);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Add_destination_markup_with_wrong_market_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                null, "5", null, DestinationMarkupScopeTypes.Market);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Add_location_markup_with_wrong_market_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                "5", null, SubjectMarkupScopeTypes.Market, null);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Add_location_markup_with_unexpected_type_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                "4", null, SubjectMarkupScopeTypes.Agent, null);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Add_destination_markup_with_unexpected_type_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                null, "4", null, DestinationMarkupScopeTypes.Accommodation);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Add_destination_agency_markup_with_unexpected_type_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                "1", "4", SubjectMarkupScopeTypes.Agency, DestinationMarkupScopeTypes.Accommodation);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Add_destination_agency_markup_with_null_agencyId_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                null, "4", SubjectMarkupScopeTypes.Agency, DestinationMarkupScopeTypes.Market);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Add_destination_agency_markup_with_wrong_agencyId_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                "4", "4", SubjectMarkupScopeTypes.Agency, DestinationMarkupScopeTypes.Market);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Add_destinaion_markup_already_exists_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, 2, Currencies.USD,
+                null, "2", null, DestinationMarkupScopeTypes.Market);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Modify_location_markup_with_wrong_policyId_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, 2, Currencies.USD,
+                null, null, null, null);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.ModifyLocationPolicy(6, settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Modify_location_or_destination_markup_with_unupdated_data_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, 2, Currencies.USD,
+                "2", "Country_12512", SubjectMarkupScopeTypes.Market, DestinationMarkupScopeTypes.Country);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.ModifyLocationPolicy(1, settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Modify_location_or_destination_markup_with_wrong_value_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, 0, Currencies.USD,
+                null, null, null, null);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.ModifyLocationPolicy(1, settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Modify_location_markup_with_not_location_policyId_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                null, null, null, null);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.ModifyLocationPolicy(5, settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Modify_destination_markup_with_not_location_policyId_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                null, null, null, null);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.ModifyLocationPolicy(4, settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        private void SetupInitialData()
+        {
+            _edoContextMock
+                .Setup(c => c.Markets)
+                .Returns(DbSetMockProvider.GetDbSetMock(markets));
+
+            _edoContextMock
+                .Setup(c => c.Agencies)
+                .Returns(DbSetMockProvider.GetDbSetMock(agencies));
+
+            _edoContextMock
+                .Setup(c => c.MarkupPolicies)
+                .Returns(DbSetMockProvider.GetDbSetMock(markupPolicies));
+
+            _edoContextMock
+                .Setup(x => x.Administrators)
+                .Returns(DbSetMockProvider.GetDbSetMock(administrators));
+            _edoContextMock
+                .Setup(x => x.AdministratorRoles)
+                .Returns(DbSetMockProvider.GetDbSetMock(administratorRoles));
+        }
+
+
+        private readonly List<Market> markets = new()
+        {
+            new Market
+            {
+                Id = 1,
+                Names = new MultiLanguage<string> { En = "Unknown" },
+            },
+            new Market
+            {
+                Id = 2,
+                Names = new MultiLanguage<string> { En = "CIS" }
+            },
+            new Market
+            {
+                Id = 3,
+                Names = new MultiLanguage<string> { En = "Africa"}
+            },
+            new Market
+            {
+                Id = 4,
+                Names = new MultiLanguage<string> { En = "Europe"}
+            }
+        };
+
+
+        private readonly List<Agency> agencies = new()
+        {
+            new Agency
+            {
+                Id = 1,
+                Name = "Test 1"
+            },
+            new Agency
+            {
+                Id = 2,
+                Name = "Test 2"
+            },
+            new Agency
+            {
+                Id = 3,
+                Name = "Test 3"
+            }
+        };
+
+
+        private readonly List<MarkupPolicy> markupPolicies = new()
+        {
+            new MarkupPolicy
+            {
+                Id = 1,
+                Value = 2,
+                Currency = Currencies.USD,
+                FunctionType = MarkupFunctionType.Percent,
+                Description = "Markup 1",
+                SubjectScopeId = "1171",
+                SubjectScopeType = SubjectMarkupScopeTypes.Agency,
+                DestinationScopeId = "1",
+                DestinationScopeType = DestinationMarkupScopeTypes.Market
+            },
+            new MarkupPolicy
+            {
+                Id = 2,
+                Value = 5,
+                Currency = Currencies.USD,
+                FunctionType = MarkupFunctionType.Percent,
+                Description = "Markup 2",
+                SubjectScopeId = string.Empty,
+                SubjectScopeType = SubjectMarkupScopeTypes.Global,
+                DestinationScopeId = "2",
+                DestinationScopeType = DestinationMarkupScopeTypes.Market
+            },
+            new MarkupPolicy
+            {
+                Id = 3,
+                Value = 1,
+                Currency = Currencies.USD,
+                FunctionType = MarkupFunctionType.Percent,
+                Description = "Markup 3",
+                SubjectScopeId = string.Empty,
+                SubjectScopeType = SubjectMarkupScopeTypes.Global,
+                DestinationScopeId = "3",
+                DestinationScopeType = DestinationMarkupScopeTypes.Market
+            },
+            new MarkupPolicy
+            {
+                Id = 4,
+                Value = 1,
+                Currency = Currencies.USD,
+                FunctionType = MarkupFunctionType.Percent,
+                Description = "Markup 3",
+                SubjectScopeId = string.Empty,
+                SubjectScopeType = SubjectMarkupScopeTypes.Global,
+                DestinationScopeId = "3",
+                DestinationScopeType = DestinationMarkupScopeTypes.Accommodation
+            },
+            new MarkupPolicy
+            {
+                Id = 5,
+                Value = 1,
+                Currency = Currencies.USD,
+                FunctionType = MarkupFunctionType.Percent,
+                Description = "Markup 3",
+                SubjectScopeId = "456",
+                SubjectScopeType = SubjectMarkupScopeTypes.Agent,
+                DestinationScopeId = string.Empty,
+                DestinationScopeType = DestinationMarkupScopeTypes.Global
+            }
+        };
+
+
+        private readonly IEnumerable<Administrator> administrators = new[]
+        {
+            new Administrator
+            {
+                Id = 0,
+                AdministratorRoleIds = new []{0},
+                IdentityHash = HashGenerator.ComputeSha256("hash"),
+                IsActive = true
+            }
+        };
+
+
+        private readonly IEnumerable<AdministratorRole> administratorRoles = new[]
+        {
+            new AdministratorRole
+            {
+                Id = 0,
+                Permissions = AdministratorPermissions.AccountReplenish | AdministratorPermissions.AdministratorInvitation
+            }
+        };
+
+
+        private readonly Mock<EdoContext> _edoContextMock;
+        private readonly IAdminMarkupPolicyManager _adminMarkupPolicyManager;
+    }
+}

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/AdminMarkupPolicyTests/AdminMarkupPolicyManagerTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/AdminMarkupPolicyTests/AdminMarkupPolicyManagerTests.cs
@@ -6,6 +6,7 @@ using HappyTravel.Edo.Api.Models.Markups;
 using HappyTravel.Edo.Api.Models.Users;
 using HappyTravel.Edo.Api.Services.Management;
 using HappyTravel.Edo.Api.Services.Markups;
+using HappyTravel.Edo.Api.Services.Messaging;
 using HappyTravel.Edo.Common.Enums;
 using HappyTravel.Edo.Common.Enums.Administrators;
 using HappyTravel.Edo.Common.Enums.Markup;
@@ -43,7 +44,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.AdminMarkupPolicyTest
 
             _adminMarkupPolicyManager = new AdminMarkupPolicyManager(_edoContextMock.Object,
                 Mock.Of<IDateTimeProvider>(), Mock.Of<IDisplayedMarkupFormulaService>(),
-                administratorContext, auditServiceMock.Object);
+                administratorContext, auditServiceMock.Object, Mock.Of<IMessageBus>());
 
             var strategy = new ExecutionStrategyMock();
 

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/AdminMarkupPolicyTests/AdminMarkupPolicyManagerTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/AdminMarkupPolicyTests/AdminMarkupPolicyManagerTests.cs
@@ -126,6 +126,18 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.AdminMarkupPolicyTest
 
 
         [Fact]
+        public async Task Add_destination_agency_markup_which_already_exist_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                "1", "1", SubjectMarkupScopeTypes.Agency, DestinationMarkupScopeTypes.Market);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
         public async Task Add_destination_agency_markup_with_unexpected_type_should_return_fail()
         {
             var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
@@ -310,7 +322,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.AdminMarkupPolicyTest
                 Currency = Currencies.USD,
                 FunctionType = MarkupFunctionType.Percent,
                 Description = "Markup 1",
-                SubjectScopeId = "1171",
+                SubjectScopeId = "1",
                 SubjectScopeType = SubjectMarkupScopeTypes.Agency,
                 DestinationScopeId = "1",
                 DestinationScopeType = DestinationMarkupScopeTypes.Market

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/FilterByMarkupDestination.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/FilterByMarkupDestination.cs
@@ -168,6 +168,47 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupPolicyServiceTe
         }
 
 
+        [Fact]
+        public void Markups_specify_agent_for_hotel_market_should_be_returned()
+        {
+            var markupSubject = GetDummyMarkupSubject();
+
+            var markupDestination = new MarkupDestinationInfo
+            {
+                AccommodationHtId = "President Hotel",
+                CountryHtId = "UAE",
+                LocalityHtId = "Dubai",
+                MarketId = 2
+            };
+
+            var markupPolicies = new List<MarkupPolicy>
+            {
+                new()
+                {
+                    Id = 1,
+                    SubjectScopeId = "1",
+                    SubjectScopeType = SubjectMarkupScopeTypes.Agency,
+                    DestinationScopeType = DestinationMarkupScopeTypes.Market,
+                    DestinationScopeId = "2"
+                },
+                new()
+                {
+                    Id = 2,
+                    SubjectScopeType = SubjectMarkupScopeTypes.Global,
+                    DestinationScopeType = DestinationMarkupScopeTypes.Market,
+                    DestinationScopeId = "1"
+                }
+            };
+
+            var service = MarkupPolicyServiceMock.Create(markupPolicies);
+
+            var policies = service.Get(markupSubject, markupDestination);
+
+            Assert.Single(policies);
+            Assert.Equal(1, policies[0].Id);
+        }
+
+
         private MarkupSubjectInfo GetDummyMarkupSubject()
             => new()
             {


### PR DESCRIPTION
Issue: https://github.com/happy-travel/agent-app-project/issues/1291
Insomnia: Edo -> Admin -> Markups -> Location Markups
Tested through insomnia and unit tests

Test case: 
1.  Add agency destination markup
2. Run search and chech if markup is applied for agency and hotel's market.