### PR TITLE
Markup by the country where the agency is located

### DIFF
--- a/Api/Models/Agents/AgentContext.cs
+++ b/Api/Models/Agents/AgentContext.cs
@@ -8,7 +8,7 @@ namespace HappyTravel.Edo.Api.Models.Agents
         public AgentContext(int agentId, string firstName, string lastName, string email,
             string title, string position, int agencyId, string agencyName, bool isMaster,
             InAgencyPermissions inAgencyPermissions, string countryHtId, string localityHtId,
-            int marketId, List<int> agencyAncestors)
+            string countryCode, int marketId, List<int> agencyAncestors)
         {
             AgentId = agentId;
             FirstName = firstName;
@@ -22,6 +22,7 @@ namespace HappyTravel.Edo.Api.Models.Agents
             InAgencyPermissions = inAgencyPermissions;
             CountryHtId = countryHtId;
             LocalityHtId = localityHtId;
+            CountryCode = countryCode;
             MarketId = marketId;
             AgencyAncestors = agencyAncestors;
         }
@@ -60,6 +61,7 @@ namespace HappyTravel.Edo.Api.Models.Agents
         public InAgencyPermissions InAgencyPermissions { get; }
         public string CountryHtId { get; }
         public string LocalityHtId { get; }
+        public string CountryCode { get; }
         public int MarketId { get; }
         public List<int> AgencyAncestors { get; }
         public string Title { get; }

--- a/Api/Services/Accommodations/Availability/AgentContextMarkupExtensions.cs
+++ b/Api/Services/Accommodations/Availability/AgentContextMarkupExtensions.cs
@@ -12,6 +12,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability
                 AgencyId = agentContext.AgencyId,
                 CountryHtId = agentContext.CountryHtId,
                 LocalityHtId = agentContext.LocalityHtId,
+                CountryCode = agentContext.CountryCode,
                 MarketId = agentContext.MarketId,
                 AgencyAncestors = agentContext.AgencyAncestors
             };

--- a/Api/Services/Agents/HttpBasedAgentContextService.cs
+++ b/Api/Services/Agents/HttpBasedAgentContextService.cs
@@ -146,6 +146,7 @@ namespace HappyTravel.Edo.Api.Services.Agents
                         inAgencyPermissions,
                         agency.CountryHtId,
                         agency.LocalityHtId,
+                        country.Code,
                         country.MarketId,
                         agency.Ancestors))
                 .SingleOrDefaultAsync();
@@ -174,6 +175,7 @@ namespace HappyTravel.Edo.Api.Services.Agents
                         inAgencyPermissions,
                         agency.CountryHtId,
                         agency.LocalityHtId,
+                        country.Code,
                         country.MarketId,
                         agency.Ancestors))
                 .SingleOrDefaultAsync();

--- a/Api/Services/Markups/Abstractions/MarkupSubjectInfo.cs
+++ b/Api/Services/Markups/Abstractions/MarkupSubjectInfo.cs
@@ -7,6 +7,7 @@ namespace HappyTravel.Edo.Api.Services.Markups.Abstractions
     {
         public string CountryHtId { get; init; }
         public string LocalityHtId { get; init; }
+        public string CountryCode { get; init; }
         public int MarketId { get; init; }
         public int AgencyId { get; init; }
         public int AgentId { get; init; }

--- a/Api/Services/Markups/AdminMarkupPolicyManager.cs
+++ b/Api/Services/Markups/AdminMarkupPolicyManager.cs
@@ -142,7 +142,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
                                 .NotNull()
                                 .MustAsync(DestinationMarkupDoesNotExist()!)
                                 .When(m => m.DestinationScopeType == DestinationMarkupScopeTypes.Market || m.DestinationScopeType == DestinationMarkupScopeTypes.Country ||
-                                    m.DestinationScopeType == DestinationMarkupScopeTypes.Locality || m.LocationScopeType is null)
+                                    m.LocationScopeType is null)
                                 .WithMessage(m => $"Destination markup policy with DestinationScopeId {m.DestinationScopeId} already exists or unexpected value!")
                                 .MustAsync(DestinationMarketExists()!)
                                 .When(m => m.DestinationScopeType == DestinationMarkupScopeTypes.Market && m.LocationScopeType is null)
@@ -150,8 +150,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
 
                             v.RuleFor(m => m.DestinationScopeType)
                                 .NotNull()
-                                .Must(d => d.Equals(DestinationMarkupScopeTypes.Market) || d.Equals(DestinationMarkupScopeTypes.Country) ||
-                                    d.Equals(DestinationMarkupScopeTypes.Locality))
+                                .Must(d => d.Equals(DestinationMarkupScopeTypes.Market) || d.Equals(DestinationMarkupScopeTypes.Country))
                                 .WithMessage($"Request's destinationScopeType must be Market, Country or Locality");
 
                             v.RuleFor(m => m.LocationScopeId)
@@ -181,8 +180,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
                                 .WithMessage(m => $"Market with id {m.LocationScopeId} doesn't exist!");
 
                             v.RuleFor(m => m.LocationScopeType)
-                                .Must(d => d.Equals(SubjectMarkupScopeTypes.Market) || d.Equals(SubjectMarkupScopeTypes.Country) ||
-                                    d.Equals(SubjectMarkupScopeTypes.Locality))
+                                .Must(d => d.Equals(SubjectMarkupScopeTypes.Market) || d.Equals(SubjectMarkupScopeTypes.Country))
                                 .WithMessage($"Request's locationScopeType must be Market, Country or Locality");
                         });
                     }, settings);

--- a/Api/Services/Markups/AdminMarkupPolicyManager.cs
+++ b/Api/Services/Markups/AdminMarkupPolicyManager.cs
@@ -145,7 +145,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
                                     m.LocationScopeType is null)
                                 .WithMessage(m => $"Destination markup policy with DestinationScopeId {m.DestinationScopeId} already exists or unexpected value!")
                                 .MustAsync(DestinationMarketExists()!)
-                                .When(m => m.DestinationScopeType == DestinationMarkupScopeTypes.Market && m.LocationScopeType is null)
+                                .When(m => m.DestinationScopeType == DestinationMarkupScopeTypes.Market && m.LocationScopeType is null, ApplyConditionTo.CurrentValidator)
                                 .WithMessage(m => $"Market with id {m.DestinationScopeId} doesn't exist!");
 
                             v.RuleFor(m => m.DestinationScopeType)
@@ -177,7 +177,10 @@ namespace HappyTravel.Edo.Api.Services.Markups
                                 .WithMessage(m => $"Location markup policy with LocationScopeId {m.LocationScopeId} already exists or unexpected value!")
                                 .MustAsync(LocationMarketExists()!)
                                 .When(m => m.LocationScopeType == SubjectMarkupScopeTypes.Market)
-                                .WithMessage(m => $"Market with id {m.LocationScopeId} doesn't exist!");
+                                .WithMessage(m => $"Market with id {m.LocationScopeId} doesn't exist!")
+                                .MustAsync(LocationCountryExists()!)
+                                .When(m => m.LocationScopeType == SubjectMarkupScopeTypes.Country, ApplyConditionTo.CurrentValidator)
+                                .WithMessage(m => $"Country with code {m.LocationScopeId} doesn't exist!");
 
                             v.RuleFor(m => m.LocationScopeType)
                                 .Must(d => d.Equals(SubjectMarkupScopeTypes.Market) || d.Equals(SubjectMarkupScopeTypes.Country))
@@ -208,7 +211,12 @@ namespace HappyTravel.Edo.Api.Services.Markups
 
             Func<string, CancellationToken, Task<bool>> LocationMarketExists()
                 => async (scopeId, cancelationToken)
-                    => await _context.Markets.AnyAsync(m => m.Id.ToString() == settings.DestinationScopeId, cancelationToken);
+                    => await _context.Markets.AnyAsync(m => m.Id.ToString() == settings.LocationScopeId, cancelationToken);
+
+
+            Func<string, CancellationToken, Task<bool>> LocationCountryExists()
+                => async (scopeId, cancelationToken)
+                    => await _context.Countries.AnyAsync(m => m.Code == settings.LocationScopeId, cancelationToken);
 
 
             Func<string, CancellationToken, Task<bool>> AgencyDestinationMarkupDoesNotExist()

--- a/Api/Services/Markups/MarkupPolicyService.cs
+++ b/Api/Services/Markups/MarkupPolicyService.cs
@@ -38,7 +38,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
                 // This code will be uncommented at the second stage of work on markups - Issue - AA #1310
                 SubjectMarkupScopeTypes.Global => true,
                 SubjectMarkupScopeTypes.Market => policy.SubjectScopeId == info.MarketId.ToString(),
-                SubjectMarkupScopeTypes.Country => policy.SubjectScopeId == info.CountryHtId,
+                SubjectMarkupScopeTypes.Country => policy.SubjectScopeId == info.CountryCode,
                 SubjectMarkupScopeTypes.Locality => false, // policy.SubjectScopeId == info.LocalityHtId,
                 SubjectMarkupScopeTypes.Agency => policy.SubjectScopeId == info.AgencyId.ToString()
                     || info.AgencyAncestors.Contains(int.Parse(policy.SubjectScopeId)),

--- a/Api/Services/Markups/MarkupPolicyService.cs
+++ b/Api/Services/Markups/MarkupPolicyService.cs
@@ -38,7 +38,7 @@ namespace HappyTravel.Edo.Api.Services.Markups
                 // This code will be uncommented at the second stage of work on markups - Issue - AA #1310
                 SubjectMarkupScopeTypes.Global => true,
                 SubjectMarkupScopeTypes.Market => policy.SubjectScopeId == info.MarketId.ToString(),
-                SubjectMarkupScopeTypes.Country => false, // policy.SubjectScopeId == info.CountryHtId,
+                SubjectMarkupScopeTypes.Country => policy.SubjectScopeId == info.CountryHtId,
                 SubjectMarkupScopeTypes.Locality => false, // policy.SubjectScopeId == info.LocalityHtId,
                 SubjectMarkupScopeTypes.Agency => policy.SubjectScopeId == info.AgencyId.ToString()
                     || info.AgencyAncestors.Contains(int.Parse(policy.SubjectScopeId)),

--- a/HappyTravel.Edo.DirectApi/Services/Overriden/AgentContextService.cs
+++ b/HappyTravel.Edo.DirectApi/Services/Overriden/AgentContextService.cs
@@ -59,6 +59,7 @@ namespace HappyTravel.Edo.DirectApi.Services.Overriden
                         agentAgencyRelation.AgentRoleIds,
                         CountryHtId = agency.CountryHtId,
                         LocalityHtId = agency.LocalityHtId,
+                        CountryCode = country.Code,
                         MarketId = country.MarketId,
                         AgencyAncestors = agency.Ancestors
                     })
@@ -79,6 +80,7 @@ namespace HappyTravel.Edo.DirectApi.Services.Overriden
                 inAgencyPermissions: await GetAggregateInAgencyPermissions(data.AgentRoleIds),
                 countryHtId: data.CountryHtId,
                 localityHtId: data.LocalityHtId,
+                countryCode: data.CountryCode,
                 marketId: data.MarketId,
                 agencyAncestors: data.AgencyAncestors);
         }

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Accommodations/Availability/AccommodationBookingSettingsServiceTests/AccommodationBookingSettingsServiceBoolTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Accommodations/Availability/AccommodationBookingSettingsServiceTests/AccommodationBookingSettingsServiceBoolTests.cs
@@ -60,21 +60,21 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability.A
                 });
             var agencySettings = default(Maybe<AgencyAccommodationBookingSettings>);
             var rootAgencySettings = default(RootAgencyAccommodationBookingSettings);
-        
+
             var (agentSettingsService, agencySettingsService, rootAgencySystemSettingsService) = GetSettingsServices(agentSettings, agencySettings, rootAgencySettings);
             var flow = GetDoubleFlow();
             var agencySupplierManagementService = GetAgencySupplierManagementService();
-        
+
             var service = new AccommodationBookingSettingsService(flow, agentSettingsService, agencySettingsService, rootAgencySystemSettingsService,
                 agencySupplierManagementService, default);
-        
+
             var settings = await service.Get(_agentContext);
-        
+
             Assert.Equal(expectedSupplierVisible, settings.IsSupplierVisible);
             Assert.Equal(expectedDirectContractFlagVisible, settings.IsDirectContractFlagVisible);
         }
-        
-        
+
+
         [Theory]
         [InlineData(false, false, false)]
         [InlineData(false, false, true)]
@@ -97,21 +97,21 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability.A
                     IsDirectContractFlagVisible = expectedDirectContractFlagVisible
                 });
             var rootAgencySettings = default(RootAgencyAccommodationBookingSettings);
-        
+
             var (agentSettingsService, agencySettingsService, rootAgencySystemSettingsService) = GetSettingsServices(agentSettings, agencySettings, rootAgencySettings);
             var flow = GetDoubleFlow();
             var agencySupplierManagementService = GetAgencySupplierManagementService();
-        
+
             var service = new AccommodationBookingSettingsService(flow, agentSettingsService, agencySettingsService, rootAgencySystemSettingsService,
                 agencySupplierManagementService, default);
-        
+
             var settings = await service.Get(_agentContext);
-        
+
             Assert.Equal(expectedSupplierVisible, settings.IsSupplierVisible);
             Assert.Equal(expectedDirectContractFlagVisible, settings.IsDirectContractFlagVisible);
         }
-        
-        
+
+
         [Theory]
         [InlineData(false, false, false, true, true, true, true, false, true)]
         [InlineData(true, false, true, false, false, false, true, true, false)]
@@ -135,16 +135,16 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability.A
                     IsDirectContractFlagVisible = agencyDirectContractFlagVisible
                 });
             var rootAgencySettings = default(RootAgencyAccommodationBookingSettings);
-        
+
             var (agentSettingsService, agencySettingsService, rootAgencySystemSettingsService) = GetSettingsServices(agentSettings, agencySettings, rootAgencySettings);
             var flow = GetDoubleFlow();
             var agencySupplierManagementService = GetAgencySupplierManagementService();
-        
+
             var service = new AccommodationBookingSettingsService(flow, agentSettingsService, agencySettingsService, rootAgencySystemSettingsService,
                 agencySupplierManagementService, default);
-        
+
             var settings = await service.Get(_agentContext);
-        
+
             Assert.Equal(expectedSupplierVisible, settings.IsSupplierVisible);
             Assert.Equal(expectedDirectContractFlagVisible, settings.IsDirectContractFlagVisible);
         }
@@ -162,7 +162,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability.A
                     (string _, Func<Task<AccommodationBookingSettings>> b, TimeSpan _, CancellationToken _) => b());
 
             mock.Setup(m => m.Options)
-                .Returns(new FlowOptions {CacheKeyDelimiter = ", "});
+                .Returns(new FlowOptions { CacheKeyDelimiter = ", " });
 
             return mock.Object;
         }
@@ -175,11 +175,11 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability.A
             var agentMock = new Mock<IAgentSystemSettingsService>();
             agentMock.Setup(m => m.GetAccommodationBookingSettings(It.IsAny<AgentContext>()))
                 .Returns(() => Task.FromResult(agentSettings));
-            
+
             var agencyMock = new Mock<IAgencySystemSettingsService>();
             agencyMock.Setup(m => m.GetAccommodationBookingSettings(It.IsAny<int>()))
                 .Returns(() => Task.FromResult(agencySettings));
-            
+
             var rootAgencySettingsMock = new Mock<IRootAgencySystemSettingsService>();
             rootAgencySettingsMock.Setup(m => m.GetAccommodationBookingSettings(It.IsAny<int>()))
                 .Returns(() => Task.FromResult(rootAgencySettings));
@@ -187,7 +187,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability.A
             return (agentMock.Object, agencyMock.Object, rootAgencySettingsMock.Object);
         }
 
-        
+
         private IAgencySupplierManagementService GetAgencySupplierManagementService()
         {
             var mock = new Mock<IAgencySupplierManagementService>();
@@ -202,6 +202,8 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability.A
         }
 
 
-        private readonly AgentContext _agentContext = new AgentContext(1, "fn", "ln", "email", "title", "pos", 1, "aName", default, default, "", "", 1, new());
+        private readonly AgentContext _agentContext =
+            new AgentContext(1, "fn", "ln", "email", "title", "pos", 1, "aName",
+                default, default, string.Empty, string.Empty, string.Empty, 1, new());
     }
 }

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Accommodations/Availability/AccommodationBookingSettingsServiceTests/AccommodationBookingSettingsServicePriorityTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Accommodations/Availability/AccommodationBookingSettingsServiceTests/AccommodationBookingSettingsServicePriorityTests.cs
@@ -32,23 +32,23 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability.A
                 { "illusions", false },
                 { "etg", true }
             };
-        
+
             var (agentSettingsService, agencySettingsService, rootAgencySystemSettingsService) = GetSettingsServices(agentSettings, agencySettings, rootAgencySettings);
             var flow = GetDoubleFlow();
             var agencySupplierManagementService = GetAgencySupplierManagementService(defaultSuppliers);
-        
+
             var service = new AccommodationBookingSettingsService(flow, agentSettingsService, agencySettingsService, rootAgencySystemSettingsService,
                 agencySupplierManagementService, default);
-        
+
             var settings = await service.Get(_agentContext);
-        
+
             Assert.Equal(DefaultAprMode, settings.AprMode);
             Assert.Equal(DefaultPassedDeadlineOffersMode, settings.PassedDeadlineOffersMode);
             Assert.Equal(default, settings.AdditionalSearchFilters);
             Assert.Equal(2, settings.EnabledConnectors.Count);
             Assert.Equal("netstorming", settings.EnabledConnectors[0]);
             Assert.Equal("etg", settings.EnabledConnectors[1]);
-            
+
         }
 
 
@@ -84,7 +84,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability.A
         public async Task AdditionalSearchFilters_setting_must_apply_exactly_when_agent_settings_found()
         {
             var agentSettings = Maybe<AgentAccommodationBookingSettings>
-                .From(new AgentAccommodationBookingSettings{ AdditionalSearchFilters = SearchFilters.BestPrice | SearchFilters.BestRoomPlans });
+                .From(new AgentAccommodationBookingSettings { AdditionalSearchFilters = SearchFilters.BestPrice | SearchFilters.BestRoomPlans });
             var agencySettings = default(Maybe<AgencyAccommodationBookingSettings>);
             var rootAgencySettings = default(RootAgencyAccommodationBookingSettings);
 
@@ -109,7 +109,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability.A
             var agentSettings = Maybe<AgentAccommodationBookingSettings>
                 .From(new AgentAccommodationBookingSettings
                 {
-                    EnabledSuppliers = new List<string> { "supplier1", "supplier2"},
+                    EnabledSuppliers = new List<string> { "supplier1", "supplier2" },
                     AprMode = AprMode.CardPurchasesOnly,
                     PassedDeadlineOffersMode = PassedDeadlineOffersMode.CardAndAccountPurchases
                 });
@@ -147,7 +147,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability.A
             var agencySettings = Maybe<AgencyAccommodationBookingSettings>
                 .From(new AgencyAccommodationBookingSettings
                 {
-                    EnabledSuppliers = new List<string> { "supplier3", "supplier4"},
+                    EnabledSuppliers = new List<string> { "supplier3", "supplier4" },
                     AprMode = AprMode.Hide,
                     PassedDeadlineOffersMode = PassedDeadlineOffersMode.Hide
                 });
@@ -219,7 +219,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability.A
                     (string _, Func<Task<AccommodationBookingSettings>> b, TimeSpan _, CancellationToken _) => b());
 
             mock.Setup(m => m.Options)
-                .Returns(new FlowOptions {CacheKeyDelimiter = ", "});
+                .Returns(new FlowOptions { CacheKeyDelimiter = ", " });
 
             return mock.Object;
         }
@@ -232,11 +232,11 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability.A
             var agentMock = new Mock<IAgentSystemSettingsService>();
             agentMock.Setup(m => m.GetAccommodationBookingSettings(It.IsAny<AgentContext>()))
                 .Returns(() => Task.FromResult(agentSettings));
-            
+
             var agencyMock = new Mock<IAgencySystemSettingsService>();
             agencyMock.Setup(m => m.GetAccommodationBookingSettings(It.IsAny<int>()))
                 .Returns(() => Task.FromResult(agencySettings));
-            
+
             var rootAgencySettingsMock = new Mock<IRootAgencySystemSettingsService>();
             rootAgencySettingsMock.Setup(m => m.GetAccommodationBookingSettings(It.IsAny<int>()))
                 .Returns(() => Task.FromResult(rootAgencySettings));
@@ -249,15 +249,17 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Accommodations.Availability.A
         {
             var enabledSuppliers = defaultSuppliers.Where(s => s.Value)
                 .ToDictionary(s => s.Key, s => s.Value);
-            
+
             var mock = new Mock<IAgencySupplierManagementService>();
             mock.Setup(m => m.GetMaterializedSuppliers(It.IsAny<int>()))
                 .Returns(Task.FromResult(Result.Success(enabledSuppliers)));
             return mock.Object;
         }
-        
 
-        private readonly AgentContext _agentContext = new(1, "fn", "ln", "email", "title", "pos", 1, "aname", default, default, "", "", 1, new());
+
+        private readonly AgentContext _agentContext =
+            new(1, "fn", "ln", "email", "title", "pos", 1, "aname",
+                default, default, string.Empty, string.Empty, string.Empty, 1, new());
 
 
         private const PassedDeadlineOffersMode DefaultPassedDeadlineOffersMode = PassedDeadlineOffersMode.DisplayOnly;

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/AdminMarkupPolicyTests/AdminMarkupPolicyManagerTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/AdminMarkupPolicyTests/AdminMarkupPolicyManagerTests.cs
@@ -105,6 +105,18 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.AdminMarkupPolicyTest
 
 
         [Fact]
+        public async Task Add_location_markup_with_wrong_country_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                "GB", null, SubjectMarkupScopeTypes.Country, null);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
         public async Task Add_location_markup_with_unexpected_type_should_return_fail()
         {
             var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
@@ -267,6 +279,10 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.AdminMarkupPolicyTest
                 .Returns(DbSetMockProvider.GetDbSetMock(markets));
 
             _edoContextMock
+                .Setup(c => c.Countries)
+                .Returns(DbSetMockProvider.GetDbSetMock(countries));
+
+            _edoContextMock
                 .Setup(c => c.Agencies)
                 .Returns(DbSetMockProvider.GetDbSetMock(agencies));
 
@@ -304,6 +320,19 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.AdminMarkupPolicyTest
             {
                 Id = 4,
                 Names = new MultiLanguage<string> { En = "Europe"}
+            }
+        };
+
+
+        private readonly List<Country> countries = new()
+        {
+            new Country
+            {
+                Code = "RU"
+            },
+            new Country
+            {
+                Code = "KZ"
             }
         };
 

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/FilterByMarkupSubject.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/FilterByMarkupSubject.cs
@@ -12,45 +12,46 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupPolicyServiceTe
     {
         // This tests will be uncommented at the second stage of work on markups - Issue - AA #1310
 
-        // [Fact]
-        // public void Markups_for_specific_agent_country_should_be_returned()
-        // {
-        //     var markupSubject = new MarkupSubjectInfo
-        //     {
-        //         AgencyAncestors = new List<int>(),
-        //         AgencyId = 1,
-        //         AgentId = 1,
-        //         CountryHtId = "Russia",
-        //         LocalityHtId = "Moscow"
-        //     };
+        [Fact]
+        public void Markups_for_specific_agent_country_should_be_returned()
+        {
+            var markupSubject = new MarkupSubjectInfo
+            {
+                AgencyAncestors = new List<int>(),
+                AgencyId = 1,
+                AgentId = 1,
+                CountryHtId = "Russia",
+                LocalityHtId = "Moscow",
+                CountryCode = "RU"
+            };
 
-        //     var markupDestination = GetDummyMarkupDestination();
+            var markupDestination = GetDummyMarkupDestination();
 
-        //     var markupPolicies = new List<MarkupPolicy>
-        //     {
-        //         new()
-        //         {
-        //             Id = 1,
-        //             SubjectScopeType = SubjectMarkupScopeTypes.Country,
-        //             SubjectScopeId = "Russia",
-        //             DestinationScopeType = DestinationMarkupScopeTypes.Global
-        //         },
-        //         new()
-        //         {
-        //             Id = 2,
-        //             SubjectScopeType = SubjectMarkupScopeTypes.Country,
-        //             SubjectScopeId = "Ukraine",
-        //             DestinationScopeType = DestinationMarkupScopeTypes.Global
-        //         }
-        //     };
+            var markupPolicies = new List<MarkupPolicy>
+            {
+                new()
+                {
+                    Id = 1,
+                    SubjectScopeType = SubjectMarkupScopeTypes.Country,
+                    SubjectScopeId = "RU",
+                    DestinationScopeType = DestinationMarkupScopeTypes.Global
+                },
+                new()
+                {
+                    Id = 2,
+                    SubjectScopeType = SubjectMarkupScopeTypes.Country,
+                    SubjectScopeId = "UK",
+                    DestinationScopeType = DestinationMarkupScopeTypes.Global
+                }
+            };
 
-        //     var service = MarkupPolicyServiceMock.Create(markupPolicies);
+            var service = MarkupPolicyServiceMock.Create(markupPolicies);
 
-        //     var policies = service.Get(markupSubject, markupDestination);
+            var policies = service.Get(markupSubject, markupDestination);
 
-        //     Assert.Single(policies);
-        //     Assert.Equal(1, policies[0].Id);
-        // }
+            Assert.Single(policies);
+            Assert.Equal(1, policies[0].Id);
+        }
 
 
         // [Fact]
@@ -250,6 +251,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupPolicyServiceTe
                 AgentId = 1,
                 CountryHtId = "Russia",
                 LocalityHtId = "Moscow",
+                CountryCode = "RU",
                 MarketId = 8
             };
 

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/OrderByAgentScopeType.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/OrderByAgentScopeType.cs
@@ -81,11 +81,11 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupPolicyServiceTe
 
             // This tests will be uncommented at the second stage of work on markups - Issue - AA #1310
             Assert.Equal(SubjectMarkupScopeTypes.Global, policies[0].SubjectScopeType);
-            // Assert.Equal(SubjectMarkupScopeTypes.Country, policies[1].SubjectScopeType);
+            Assert.Equal(SubjectMarkupScopeTypes.Country, policies[1].SubjectScopeType);
             // Assert.Equal(SubjectMarkupScopeTypes.Locality, policies[2].SubjectScopeType);
-            Assert.Equal(SubjectMarkupScopeTypes.Agency, policies[1].SubjectScopeType);
+            Assert.Equal(SubjectMarkupScopeTypes.Agency, policies[2].SubjectScopeType);
             // Assert.Equal(SubjectMarkupScopeTypes.Agent, policies[4].SubjectScopeType);            
-            Assert.Equal(SubjectMarkupScopeTypes.Market, policies[2].SubjectScopeType);
+            Assert.Equal(SubjectMarkupScopeTypes.Market, policies[3].SubjectScopeType);
         }
     }
 }

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/OrderByAgentScopeType.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/OrderByAgentScopeType.cs
@@ -20,6 +20,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupPolicyServiceTe
                 AgentId = 1,
                 CountryHtId = "Russia",
                 LocalityHtId = "Moscow",
+                CountryCode = "RU",
                 MarketId = 8
             };
 
@@ -56,7 +57,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupPolicyServiceTe
                 {
                     Id = 5,
                     SubjectScopeType = SubjectMarkupScopeTypes.Country,
-                    SubjectScopeId = "Russia",
+                    SubjectScopeId = "RU",
                     DestinationScopeType = DestinationMarkupScopeTypes.Global
                 },
                 new()

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/BalanceManagementNotifications.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/BalanceManagementNotifications.cs
@@ -28,12 +28,12 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         public BalanceManagementNotifications()
         {
             var entityLockerMock = new Mock<IEntityLocker>();
-    
+
             entityLockerMock.Setup(l => l.Acquire<It.IsAnyType>(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(Result.Success()));
-            
+
             var edoContextMock = MockEdoContextFactory.Create();
             _mockedEdoContext = edoContextMock.Object;
-    
+
             var accountPaymentProcessingService = new AccountPaymentProcessingService(
                 _mockedEdoContext, entityLockerMock.Object, Mock.Of<IAccountBalanceAuditService>());
 
@@ -41,13 +41,13 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
             _accountPaymentService = new AccountPaymentService(accountPaymentProcessingService, _mockedEdoContext,
                 new DefaultDateTimeProvider(), _balanceManagementNotificationsServiceMock.Object, Mock.Of<IBookingRecordManager>(),
                 Mock.Of<IBookingDocumentsMailingService>());
-    
+
             var strategy = new ExecutionStrategyMock();
-    
+
             var dbFacade = new Mock<DatabaseFacade>(_mockedEdoContext);
             dbFacade.Setup(d => d.CreateExecutionStrategy()).Returns(strategy);
             edoContextMock.Setup(c => c.Database).Returns(dbFacade.Object);
-    
+
             edoContextMock
                 .Setup(c => c.Agencies)
                 .Returns(DbSetMockProvider.GetDbSetMock(new List<Agency>
@@ -69,26 +69,26 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
 
             edoContextMock
                 .Setup(c => c.Detach(_account));
-            
+
             edoContextMock
                 .Setup(c => c.Payments)
                 .Returns(DbSetMockProvider.GetDbSetMock(new List<Payment>()));
         }
 
-    
-    
+
+
         [Fact]
         public async Task Successful_charge_should_call_notification_with_correct_parameters()
         {
             var chargingAmount = new MoneyAmount(100, Currencies.USD);
             var paymentService = CreatePaymentServiceWithMoneyAmount(chargingAmount);
-            
+
             var (isSuccess, _, _, _) = await _accountPaymentService.Charge("ReferenceCode", _agent.ToApiCaller(), paymentService);
-    
+
             _balanceManagementNotificationsServiceMock.Verify(x => x.SendNotificationIfRequired(It.IsAny<AgencyAccount>(), chargingAmount));
         }
-    
-    
+
+
         private IPaymentCallbackService CreatePaymentServiceWithMoneyAmount(MoneyAmount moneyAmount)
         {
             var paymentServiceMock = new Mock<IPaymentCallbackService>();
@@ -105,14 +105,14 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
 
             return paymentServiceMock.Object;
         }
-    
-    
+
+
         public void Dispose()
         {
-    
+
         }
 
-    
+
         private readonly AgencyAccount _account = new()
         {
             Id = 1,
@@ -122,10 +122,12 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
             IsActive = true
         };
 
-        
+
         private readonly EdoContext _mockedEdoContext;
         private readonly Mock<IBalanceManagementNotificationsService> _balanceManagementNotificationsServiceMock;
         private readonly AccountPaymentService _accountPaymentService;
-        private readonly AgentContext _agent = new(1, "", "", "", "", "", 1, "", true, InAgencyPermissions.All, "", "", 1, new());
+        private readonly AgentContext _agent =
+            new(1, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty,
+                1, string.Empty, true, InAgencyPermissions.All, string.Empty, string.Empty, string.Empty, 1, new());
     }
 }

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/ChargeMoneyTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/ChargeMoneyTests.cs
@@ -29,25 +29,25 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         public ChargeMoneyTests()
         {
             var entityLockerMock = new Mock<IEntityLocker>();
-    
+
             entityLockerMock.Setup(l => l.Acquire<It.IsAnyType>(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(Result.Success()));
-            
+
             var edoContextMock = MockEdoContextFactory.Create();
             _mockedEdoContext = edoContextMock.Object;
-    
+
             var accountPaymentProcessingService = new AccountPaymentProcessingService(
                 _mockedEdoContext, entityLockerMock.Object, Mock.Of<IAccountBalanceAuditService>());
-    
+
             _accountPaymentService = new AccountPaymentService(accountPaymentProcessingService, _mockedEdoContext,
                 new DefaultDateTimeProvider(), Mock.Of<IBalanceManagementNotificationsService>(),
                 Mock.Of<IBookingRecordManager>(), Mock.Of<IBookingDocumentsMailingService>());
-    
+
             var strategy = new ExecutionStrategyMock();
-    
+
             var dbFacade = new Mock<DatabaseFacade>(_mockedEdoContext);
             dbFacade.Setup(d => d.CreateExecutionStrategy()).Returns(strategy);
             edoContextMock.Setup(c => c.Database).Returns(dbFacade.Object);
-    
+
             edoContextMock
                 .Setup(c => c.Agencies)
                 .Returns(DbSetMockProvider.GetDbSetMock(new List<Agency>
@@ -69,33 +69,33 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
 
             edoContextMock
                 .Setup(c => c.Detach(_account));
-            
+
             edoContextMock
                 .Setup(c => c.Payments)
                 .Returns(DbSetMockProvider.GetDbSetMock(new List<Payment>()));
         }
 
-    
-    
+
+
         [Fact]
         public async Task Successful_charge_should_lower_balance()
         {
             var paymentService = CreatePaymentServiceWithMoneyAmount(new MoneyAmount(100, Currencies.USD));
-            
+
             var (isSuccess, _, _, _) = await _accountPaymentService.Charge("ReferenceCode", _agent.ToApiCaller(), paymentService);
-    
+
             Assert.True(isSuccess);
             Assert.Equal(900m, _account.Balance);
         }
-    
-    
+
+
         [Fact]
         public async Task Successful_charge_should_process_changes()
         {
             var paymentServiceMock = CreatePaymentServiceMock();
-            
+
             var (isSuccess, _, _, _) = await _accountPaymentService.Charge("referenceCode", _agent.ToApiCaller(), paymentServiceMock.Object);
-        
+
             Assert.True(isSuccess);
             paymentServiceMock.Verify(p => p.ProcessPaymentChanges(It.IsAny<Payment>()), Times.Once);
 
@@ -116,56 +116,56 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
                 return paymentServiceMock;
             }
         }
-    
-    
+
+
         [Fact]
         public async Task Successful_charge_should_set_payment_status()
         {
             var paymentService = CreatePaymentServiceWithMoneyAmount(new MoneyAmount(100, Currencies.USD));
-            
+
             var (isSuccess, _, _, _) = await _accountPaymentService.Charge("ReferenceCode", _agent.ToApiCaller(), paymentService);
-    
+
             Assert.True(isSuccess);
             Assert.True(_mockedEdoContext.Payments.Any());
             Assert.Equal(PaymentStatuses.Captured, _mockedEdoContext.Payments.First().Status);
         }
-    
-    
+
+
         [Fact]
         public async Task Charge_from_account_with_balance_more_allowed_overdraft_should_succeed()
         {
             _account.Balance = 25m;
             var paymentService = CreatePaymentServiceWithMoneyAmount(new MoneyAmount(100, Currencies.USD));
-    
+
             var (isSuccess, _, _, _) = await _accountPaymentService.Charge("ReferenceCode", _agent.ToApiCaller(), paymentService);
-    
+
             Assert.True(isSuccess);
             Assert.Equal(-75m, _account.Balance);
         }
-    
-    
+
+
         [Fact]
         public async Task Charge_from_account_with_insufficient_overdraft_should_fail()
         {
             var startingBalance = _account.Balance = 24m;
             var paymentService = CreatePaymentServiceWithMoneyAmount(new MoneyAmount(100, Currencies.USD));
-    
+
             var (_, isFailure, _, _) = await _accountPaymentService.Charge("ReferenceCode", _agent.ToApiCaller(), paymentService);
-    
+
             Assert.True(isFailure);
             Assert.Equal(startingBalance, _account.Balance);
         }
-    
-    
+
+
         [Fact]
         public async Task Charge_from_nonexistent_booking_should_fail()
         {
             var paymentService = CreatePaymentServiceWithoutServicePrice();
-            
+
             var (_, isFailure, _, _) = await _accountPaymentService.Charge("REFCODE" + " wrong code", _agent.ToApiCaller(), paymentService);
-        
+
             Assert.True(isFailure);
-            
+
             IPaymentCallbackService CreatePaymentServiceWithoutServicePrice()
             {
                 var paymentServiceMock = new Mock<IPaymentCallbackService>();
@@ -176,18 +176,18 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
                 return paymentServiceMock.Object;
             }
         }
-    
-    
+
+
         [Fact]
         public async Task Charge_when_no_account_with_booking_currency_should_fail()
         {
             var paymentService = CreatePaymentServiceWithoutAgencyAccount();
-            
+
             var (_, isFailure, _, _) = await _accountPaymentService.Charge("referenceCode", _agent.ToApiCaller(), paymentService);
-        
+
             Assert.True(isFailure);
-            
-            
+
+
             IPaymentCallbackService CreatePaymentServiceWithoutAgencyAccount()
             {
                 var paymentServiceMock = new Mock<IPaymentCallbackService>();
@@ -201,8 +201,8 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
                 return paymentServiceMock.Object;
             }
         }
-        
-        
+
+
         private IPaymentCallbackService CreatePaymentServiceWithMoneyAmount(MoneyAmount moneyAmount)
         {
             var paymentServiceMock = new Mock<IPaymentCallbackService>();
@@ -219,14 +219,14 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
 
             return paymentServiceMock.Object;
         }
-    
-    
+
+
         public void Dispose()
         {
-    
+
         }
 
-    
+
         private readonly AgencyAccount _account = new()
         {
             Id = 1,
@@ -236,9 +236,11 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
             IsActive = true
         };
 
-        
+
         private readonly EdoContext _mockedEdoContext;
         private readonly AccountPaymentService _accountPaymentService;
-        private readonly AgentContext _agent = new(1, "", "", "", "", "", 1, "", true, InAgencyPermissions.All, "", "", 1, new());
+        private readonly AgentContext _agent =
+            new(1, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty,
+                1, string.Empty, true, InAgencyPermissions.All, string.Empty, string.Empty, string.Empty, 1, new());
     }
 }

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/RefundMoneyTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/RefundMoneyTests.cs
@@ -28,11 +28,11 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         public RefundMoneyTests()
         {
             var entityLockerMock = new Mock<IEntityLocker>();
-    
+
             entityLockerMock.Setup(l => l.Acquire<It.IsAnyType>(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(Result.Success()));
-    
+
             var edoContextMock = MockEdoContextFactory.Create();
-            
+
             edoContextMock
                 .Setup(c => c.Agents)
                 .Returns(DbSetMockProvider.GetDbSetMock(new List<Agent>
@@ -43,30 +43,30 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
                         Email = "email"
                     },
                 }));
-            
+
             var edoContextMock1 = edoContextMock;
             var mockedEdoContext = edoContextMock.Object;
-    
+
             var accountPaymentProcessingService = new AccountPaymentProcessingService(
                 mockedEdoContext, entityLockerMock.Object, Mock.Of<IAccountBalanceAuditService>());
-    
+
             var dateTimeProviderMock = new Mock<IDateTimeProvider>();
             dateTimeProviderMock.Setup(d => d.UtcNow()).Returns(CancellationDate);
 
             var bookingRecordManagerMock = new Mock<IBookingRecordManager>();
             bookingRecordManagerMock.Setup(b => b.Get(It.IsAny<string>()))
                 .ReturnsAsync(Booking);
-    
+
             _accountPaymentService = new AccountPaymentService(accountPaymentProcessingService, mockedEdoContext,
                 dateTimeProviderMock.Object, Mock.Of<IBalanceManagementNotificationsService>(),
                 bookingRecordManagerMock.Object, Mock.Of<IBookingDocumentsMailingService>());
-    
+
             var strategy = new ExecutionStrategyMock();
-    
+
             var dbFacade = new Mock<DatabaseFacade>(mockedEdoContext);
             dbFacade.Setup(d => d.CreateExecutionStrategy()).Returns(strategy);
             edoContextMock.Setup(c => c.Database).Returns(dbFacade.Object);
-    
+
             edoContextMock1
                 .Setup(c => c.Agencies)
                 .Returns(DbSetMockProvider.GetDbSetMock(new List<Agency>
@@ -78,15 +78,15 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
                         ParentId = null,
                     },
                 }));
-    
+
             edoContextMock1
                 .Setup(c => c.AgencyAccounts)
                 .Returns(DbSetMockProvider.GetDbSetMock(new List<AgencyAccount>
                 {
                     _account,
                 }));
-    
-   
+
+
             edoContextMock1
                 .Setup(c => c.Payments)
                 .Returns(DbSetMockProvider.GetDbSetMock(new List<Payment>
@@ -94,43 +94,43 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
                     _payment,
                 }));
         }
-    
-    
+
+
         [Fact]
         public async Task Successful_refund_should_rise_balance()
         {
             var paymentService = CreatePaymentServiceWithRefundableAmount(new MoneyAmount(100, Currencies.USD));
-            
-            var (isSuccess, _, _) = await _accountPaymentService.Refund("ReferenceCode", _agent.ToApiCaller(),  CancellationDate, paymentService, "reason");
-    
+
+            var (isSuccess, _, _) = await _accountPaymentService.Refund("ReferenceCode", _agent.ToApiCaller(), CancellationDate, paymentService, "reason");
+
             Assert.True(isSuccess);
             Assert.Equal(1100m, _account.Balance);
         }
-        
-        
+
+
         [Fact]
         public async Task Successful_refund_should_change_payment_status()
         {
             var paymentService = CreatePaymentServiceWithRefundableAmount(new MoneyAmount(100, Currencies.USD));
-            
+
             var (isSuccess, _, error) = await _accountPaymentService.Refund("ReferenceCode", _agent.ToApiCaller(), CancellationDate, paymentService, "reason");
-        
+
             Assert.True(isSuccess);
             Assert.Equal(PaymentStatuses.Refunded, _payment.Status);
         }
-        
-        
+
+
         [Fact]
         public async Task Refund_booking_with_not_existing_agency_account_should_fail()
         {
             var paymentService = CreatePaymentServiceWithInvalidAccount();
-            
-            var (_, isFailure, _) = await _accountPaymentService.Refund("ReferenceCode", _agent.ToApiCaller(),  CancellationDate, paymentService, "reason");
-        
+
+            var (_, isFailure, _) = await _accountPaymentService.Refund("ReferenceCode", _agent.ToApiCaller(), CancellationDate, paymentService, "reason");
+
             Assert.True(isFailure);
             Assert.Equal(1000m, _account.Balance);
-            
-            
+
+
             IPaymentCallbackService CreatePaymentServiceWithInvalidAccount()
             {
                 var paymentServiceMock = new Mock<IPaymentCallbackService>();
@@ -148,21 +148,21 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
                 return paymentServiceMock.Object;
             }
         }
-        
-        
+
+
         [Fact]
         public async Task Refund_booking_without_payment_should_fail()
         {
             var paymentService = CreatePaymentServiceWithRefundableAmount(new MoneyAmount(100, Currencies.USD));
-            
+
             var (_, isFailure, _) = await _accountPaymentService.Refund("InvalidReferenceCode", _agent.ToApiCaller(), CancellationDate, paymentService, "reason");
-        
+
             Assert.True(isFailure);
             Assert.Equal(1000m, _account.Balance);
         }
-        
-        
-        
+
+
+
         private IPaymentCallbackService CreatePaymentServiceWithRefundableAmount(MoneyAmount moneyAmount)
         {
             var paymentServiceMock = new Mock<IPaymentCallbackService>();
@@ -179,14 +179,14 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
 
             return paymentServiceMock.Object;
         }
-    
-    
+
+
         public void Dispose()
         {
-    
+
         }
-    
-    
+
+
         private readonly AgencyAccount _account = new()
         {
             Id = 1,
@@ -195,7 +195,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
             AgencyId = 1,
             IsActive = true
         };
-    
+
         private readonly Payment _payment = new()
         {
             Id = 1,
@@ -205,13 +205,15 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         };
 
         private static readonly DateTimeOffset CancellationDate = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
-        private static readonly Booking Booking = new Booking 
-        { 
+        private static readonly Booking Booking = new Booking
+        {
             AgentId = 1,
             ReferenceCode = "ReferenceCode"
         };
 
         private readonly AccountPaymentService _accountPaymentService;
-        private readonly AgentContext _agent = new(1, "", "", "", "", "", 1, "", true, InAgencyPermissions.All, "", "", 1, new());
+        private readonly AgentContext _agent =
+            new(1, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty,
+                1, string.Empty, true, InAgencyPermissions.All, string.Empty, string.Empty, string.Empty, 1, new());
     }
 }

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/TransferMoneyTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Payments/Accounts/AccountPaymentServiceTests/TransferMoneyTests.cs
@@ -121,7 +121,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         public async Task Nonexistent_payer_account_should_fail()
         {
             var agent = GetAgentForAgency(1);
-            
+
             var (_, isFailure, _) = await _accountPaymentService.TransferToChildAgency(0, 2, new MoneyAmount(1m, Currencies.USD), agent);
 
             Assert.True(isFailure);
@@ -132,7 +132,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         public async Task Nonexistent_recipient_account_should_fail()
         {
             var agent = GetAgentForAgency(1);
-            
+
             var (_, isFailure, _) = await _accountPaymentService.TransferToChildAgency(1, 0, new MoneyAmount(1m, Currencies.USD), agent);
 
             Assert.True(isFailure);
@@ -154,7 +154,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         public async Task Negative_amount_transfer_should_fail()
         {
             var agent = GetAgentForAgency(1);
-            
+
             var (_, isFailure, _) = await _accountPaymentService.TransferToChildAgency(1, 2, new MoneyAmount(-1m, Currencies.USD), agent);
 
             Assert.True(isFailure);
@@ -165,7 +165,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         public async Task Transfer_to_not_child_agency_should_fail()
         {
             var agent = GetAgentForAgency(1);
-            
+
             var (_, isFailure, _) = await _accountPaymentService.TransferToChildAgency(1, 3, new MoneyAmount(1m, Currencies.USD), agent);
 
             Assert.True(isFailure);
@@ -176,7 +176,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         public async Task Transfer_to_account_with_different_currency_should_fail()
         {
             var agent = GetAgentForAgency(1);
-            
+
             var (_, isFailure, _) = await _accountPaymentService.TransferToChildAgency(1, 4, new MoneyAmount(1m, Currencies.USD), agent);
 
             Assert.True(isFailure);
@@ -187,7 +187,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         public async Task Transfer_amount_with_different_currency_should_fail()
         {
             var agent = GetAgentForAgency(1);
-            
+
             var (_, isFailure, _) = await _accountPaymentService.TransferToChildAgency(1, 2, new MoneyAmount(1m, Currencies.EUR), agent);
 
             Assert.True(isFailure);
@@ -198,7 +198,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         public async Task Transfer_when_balance_insufficient_should_fail()
         {
             var agent = GetAgentForAgency(1);
-            
+
             var (_, isFailure, _) = await _accountPaymentService.TransferToChildAgency(1, 2, new MoneyAmount(1000000m, Currencies.USD), agent);
 
             Assert.True(isFailure);
@@ -209,7 +209,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
         public async Task Correct_transfer_should_succeed()
         {
             var agent = GetAgentForAgency(1);
-            
+
             var (isSuccess, _, _) = await _accountPaymentService.TransferToChildAgency(1, 2, new MoneyAmount(1m, Currencies.USD), agent);
 
             Assert.True(isSuccess);
@@ -244,7 +244,8 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Payments.Accounts.AccountPaym
 
         private AgentContext GetAgentForAgency(int agencyId)
         {
-            return new AgentContext(1, "", "", "", "", "", agencyId, "", true, InAgencyPermissions.All, "", "", 1, new());
+            return new AgentContext(1, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty,
+                agencyId, string.Empty, true, InAgencyPermissions.All, string.Empty, string.Empty, string.Empty, 1, new());
         }
 
         public void Dispose()

--- a/HappyTravel.Edo.UnitTests/Utility/AgentContextFactory.cs
+++ b/HappyTravel.Edo.UnitTests/Utility/AgentContextFactory.cs
@@ -7,13 +7,15 @@ namespace HappyTravel.Edo.UnitTests.Utility
     {
         public static AgentContext CreateByAgentId(int agentId)
         {
-            return new(agentId, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, 0, string.Empty, true, InAgencyPermissions.All, "", "", 1, new());
+            return new(agentId, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty,
+                0, string.Empty, true, InAgencyPermissions.All, string.Empty, string.Empty, string.Empty, 1, new());
         }
 
 
         public static AgentContext CreateWithAgency(int agentId, int agencyId)
         {
-            return new(agentId, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, agencyId, string.Empty, true, InAgencyPermissions.All, "", "", 1, new());
+            return new(agentId, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty,
+                agencyId, string.Empty, true, InAgencyPermissions.All, string.Empty, string.Empty, string.Empty, 1, new());
         }
     }
 }


### PR DESCRIPTION
Issue: https://github.com/happy-travel/agent-app-project/issues/1373
Insomnia: Edo -> Admin -> Markups -> Location Markups
Tested through unit tests and insomnia

Test case:
1) Add country location markup through POST endpoint ../admin/location-markups and check validators
2) Start availability search by agency from country which markup was added before
3) Check if markup was applied