### PR TITLE
Markup according to the country where the hotel is located

### DIFF
--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -2157,6 +2157,11 @@
         </member>
         <member name="P:HappyTravel.Edo.Api.Models.Accommodations.RoomContractSetAvailability.MarketId">
             <summary>
+            Market of accommodation
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Accommodations.RoomContractSetAvailability.CountryCode">
+            <summary>
             Country code of accommodation
             </summary>
         </member>

--- a/Api/Models/Accommodations/AccommodationAvailabilityResult.cs
+++ b/Api/Models/Accommodations/AccommodationAvailabilityResult.cs
@@ -10,7 +10,7 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         [JsonConstructor]
         public AccommodationAvailabilityResult(Guid searchId, string supplierCode, DateTimeOffset created, string availabilityId,
             List<RoomContractSet> roomContractSets, decimal minPrice, decimal maxPrice, DateTimeOffset checkInDate, DateTimeOffset checkOutDate, string htId, string supplierAccommodationCode, string countryHtId,
-            string localityHtId, int marketId)
+            string localityHtId, int marketId, string countryCode)
         {
             SearchId = searchId;
             SupplierCode = supplierCode;
@@ -26,6 +26,7 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
             CountryHtId = countryHtId;
             LocalityHtId = localityHtId;
             MarketId = marketId;
+            CountryCode = countryCode;
         }
 
         [JsonIgnore]
@@ -44,5 +45,6 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         public string CountryHtId { get; init; }
         public string LocalityHtId { get; init; }
         public int MarketId { get; init; }
+        public string CountryCode { get; init; }
     }
 }

--- a/Api/Models/Accommodations/RoomContractSetAvailability.cs
+++ b/Api/Models/Accommodations/RoomContractSetAvailability.cs
@@ -10,7 +10,7 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         [JsonConstructor]
         public RoomContractSetAvailability(string availabilityId, DateTimeOffset checkInDate, DateTimeOffset checkOutDate, int numberOfNights,
             in SlimAccommodation accommodation, in RoomContractSet roomContractSet, List<PaymentTypes> availablePaymentMethods,
-            string countryHtId, string localityHtId, string evaluationToken, int marketId)
+            string countryHtId, string localityHtId, string evaluationToken, int marketId, string countryCode)
         {
             AvailabilityId = availabilityId;
             CheckInDate = checkInDate;
@@ -23,6 +23,7 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
             LocalityHtId = localityHtId;
             EvaluationToken = evaluationToken;
             MarketId = marketId;
+            CountryCode = countryCode;
         }
 
         /// <summary>
@@ -76,8 +77,13 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
         public string EvaluationToken { get; }
 
         /// <summary>
-        /// Country code of accommodation
+        /// Market of accommodation
         /// </summary>
         public int MarketId { get; }
+
+        /// <summary>
+        /// Country code of accommodation
+        /// </summary>
+        public string CountryCode { get; }
     }
 }

--- a/Api/Models/Accommodations/SingleAccommodationAvailability.cs
+++ b/Api/Models/Accommodations/SingleAccommodationAvailability.cs
@@ -12,7 +12,8 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
             string htId,
             string countryHtId,
             string localityHtId,
-            int marketId)
+            int marketId,
+            string countryCode)
         {
             AvailabilityId = availabilityId;
             CheckInDate = checkInDate;
@@ -21,6 +22,7 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
             CountryHtId = countryHtId;
             LocalityHtId = localityHtId;
             MarketId = marketId;
+            CountryCode = countryCode;
         }
 
         public string AvailabilityId { get; }
@@ -35,5 +37,6 @@ namespace HappyTravel.Edo.Api.Models.Accommodations
 
         public string LocalityHtId { get; }
         public int MarketId { get; }
+        public string CountryCode { get; }
     }
 }

--- a/Api/Models/Availabilities/Mapping/SupplierCodeMapping.cs
+++ b/Api/Models/Availabilities/Mapping/SupplierCodeMapping.cs
@@ -7,5 +7,6 @@ namespace HappyTravel.Edo.Api.Models.Availabilities.Mapping
         public string LocalityHtId { get; init; }
         public string CountryHtId { get; init; }
         public int MarketId { get; init; }
+        public string CountryCode { get; init; }
     }
 }

--- a/Api/Services/Accommodations/Availability/Mapping/AvailabilitySearchAreaService.cs
+++ b/Api/Services/Accommodations/Availability/Mapping/AvailabilitySearchAreaService.cs
@@ -56,7 +56,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Mapping
                         SupplierCode = supplierInfo.Value,
                         CountryHtId = location.CountryHtId,
                         LocalityHtId = location.LocalityHtId,
-                        MarketId = marketId
+                        MarketId = marketId,
+                        CountryCode = location.CountryCode
                     };
 
                     var supplierCode = supplierInfo.Key;

--- a/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationPolicyProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationPolicyProcessor.cs
@@ -17,7 +17,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 countryHtId: availability.CountryHtId,
                 localityHtId: availability.LocalityHtId,
                 evaluationToken: availability.EvaluationToken,
-                marketId: availability.MarketId);
+                marketId: availability.MarketId,
+                countryCode: availability.CountryCode);
         }
     }
 }

--- a/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationPriceProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationPriceProcessor.cs
@@ -39,7 +39,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 countryHtId: value.CountryHtId,
                 localityHtId: value.LocalityHtId,
                 evaluationToken: value.EvaluationToken,
-                marketId: value.MarketId);
+                marketId: value.MarketId,
+                countryCode: value.CountryCode);
         }
 
 
@@ -57,7 +58,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 countryHtId: value.CountryHtId,
                 localityHtId: value.LocalityHtId,
                 evaluationToken: value.EvaluationToken,
-                marketId: value.MarketId);
+                marketId: value.MarketId,
+                countryCode: value.CountryCode);
         }
 
 
@@ -67,7 +69,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 AccommodationHtId = availability.Accommodation.HtId,
                 CountryHtId = availability.CountryHtId,
                 LocalityHtId = availability.LocalityHtId,
-                MarketId = availability.MarketId
+                MarketId = availability.MarketId,
+                CountryCode = availability.CountryCode
             };
 
 

--- a/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationService.cs
+++ b/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/BookingEvaluationService.cs
@@ -105,7 +105,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 .Map(ApplySearchSettings);
 
 
-            async Task<Result<(string SupplierCode, RoomContractSet RoomContractSet, string AvailabilityId, string htId, string CountryHtId, string LocalityHtId, int MarketId)>>
+            async Task<Result<(string SupplierCode, RoomContractSet RoomContractSet, string AvailabilityId, string htId,
+                string CountryHtId, string LocalityHtId, int MarketId, string CountryCode)>>
                 GetSelectedRoomSet(Guid searchId, string htId, Guid roomContractSetId)
             {
                 var result = (await _roomSelectionStorage.GetResult(searchId, htId, settings.EnabledConnectors))
@@ -113,20 +114,21 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                     {
                         return r.Result.RoomContractSets
                             .Select(rs => (Source: r.SupplierCode, RoomContractSet: rs, r.Result.AvailabilityId, r.Result.HtId,
-                                CountryHtId: r.Result.CountryHtId, LocalityHtId: r.Result.LocalityHtId, r.Result.MarketId));
+                                CountryHtId: r.Result.CountryHtId, LocalityHtId: r.Result.LocalityHtId, r.Result.MarketId, r.Result.CountryCode));
                     })
                     .SingleOrDefault(r => r.RoomContractSet.Id == roomContractSetId);
 
                 if (result.Equals(default))
-                    return Result.Failure<(string, RoomContractSet, string, string, string, string, int)>("Could not find selected room contract set");
+                    return Result.Failure<(string, RoomContractSet, string, string, string, string, int, string)>("Could not find selected room contract set");
 
                 return result;
             }
 
 
-            Task<Result<EdoContracts.Accommodations.RoomContractSetAvailability?, ProblemDetails>> EvaluateOnConnector((string, RoomContractSet, string, string, string, string, int) selectedSet)
+            Task<Result<EdoContracts.Accommodations.RoomContractSetAvailability?, ProblemDetails>>
+                EvaluateOnConnector((string, RoomContractSet, string, string, string, string, int, string) selectedSet)
             {
-                var (supplier, roomContractSet, availabilityId, _, _, _, _) = selectedSet;
+                var (supplier, roomContractSet, availabilityId, _, _, _, _, _) = selectedSet;
                 return _supplierConnectorManager
                     .Get(supplier)
                     .GetExactAvailability(availabilityId, roomContractSet.Id, languageCode);
@@ -148,7 +150,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                     countryHtId: result.CountryHtId,
                     localityHtId: result.LocalityHtId,
                     evaluationToken: evaluationToken,
-                    marketId: result.MarketId);
+                    marketId: result.MarketId,
+                    countryCode: result.CountryCode);
             }
 
 
@@ -268,7 +271,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                     countryHtId: availability.CountryHtId,
                     localityHtId: availability.LocalityHtId,
                     evaluationToken: availability.EvaluationToken,
-                    marketId: availability.MarketId);
+                    marketId: availability.MarketId,
+                    countryCode: availability.CountryCode);
             }
 
 

--- a/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/RoomContractSetAvailabilityExtensions.cs
+++ b/Api/Services/Accommodations/Availability/Steps/BookingEvaluation/RoomContractSetAvailabilityExtensions.cs
@@ -8,7 +8,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
     {
         public static RoomContractSetAvailability ToRoomContractSetAvailability(
             this in EdoContracts.Accommodations.RoomContractSetAvailability availabilityValue, string supplier, string supplierCode,
-            List<PaymentTypes> paymentMethods, SlimAccommodation accommodation, string countryHtId, string localityHtId, string evaluationToken, int marketId)
+            List<PaymentTypes> paymentMethods, SlimAccommodation accommodation, string countryHtId, string localityHtId,
+            string evaluationToken, int marketId, string countryCode)
         {
             return new RoomContractSetAvailability(availabilityId: availabilityValue.AvailabilityId,
                 checkInDate: availabilityValue.CheckInDate,
@@ -20,7 +21,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.Booking
                 countryHtId: countryHtId,
                 localityHtId: localityHtId,
                 evaluationToken: evaluationToken,
-                marketId: marketId);
+                marketId: marketId,
+                countryCode: countryCode);
         }
     }
 }

--- a/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionPolicyProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionPolicyProcessor.cs
@@ -21,7 +21,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                     htId: availability.HtId,
                     countryHtId: availability.CountryHtId,
                     localityHtId: availability.LocalityHtId,
-                    marketId: availability.MarketId);
+                    marketId: availability.MarketId,
+                    countryCode: availability.CountryCode);
         }
     }
 }

--- a/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionPriceProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionPriceProcessor.cs
@@ -39,7 +39,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                 htId: availabilityDetails.HtId,
                 countryHtId: availabilityDetails.CountryHtId,
                 localityHtId: availabilityDetails.LocalityHtId,
-                marketId: availabilityDetails.MarketId);
+                marketId: availabilityDetails.MarketId,
+                countryCode: availabilityDetails.CountryCode);
         }
 
 
@@ -63,7 +64,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                 htId: response.HtId,
                 countryHtId: response.CountryHtId,
                 localityHtId: response.LocalityHtId,
-                marketId: response.MarketId);
+                marketId: response.MarketId,
+                countryCode: response.CountryCode);
         }
 
 
@@ -76,7 +78,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                 htId: source.HtId,
                 countryHtId: source.CountryHtId,
                 localityHtId: source.LocalityHtId,
-                marketId: source.MarketId);
+                marketId: source.MarketId,
+                countryCode: source.CountryCode);
         }
 
 
@@ -86,7 +89,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                 AccommodationHtId = availability.HtId,
                 CountryHtId = availability.CountryHtId,
                 LocalityHtId = availability.LocalityHtId,
-                MarketId = availability.MarketId
+                MarketId = availability.MarketId,
+                CountryCode = availability.CountryCode
             };
 
 

--- a/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionService.cs
+++ b/Api/Services/Accommodations/Availability/Steps/RoomSelection/RoomSelectionService.cs
@@ -107,7 +107,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.RoomSel
                     .Create(scope.ServiceProvider)
                     .GetSupplierAvailability(searchId: searchId, htId: htId, supplierCode: source, supplierAccommodationCode: result.SupplierAccommodationCode,
                         availabilityId: result.AvailabilityId, settings: searchSettings, agent: agent, languageCode: languageCode,
-                        countryHtId: result.CountryHtId, localityHtId: result.LocalityHtId, result.MarketId);
+                        countryHtId: result.CountryHtId, localityHtId: result.LocalityHtId, result.MarketId, result.CountryCode);
             }
 
 

--- a/Api/Services/Accommodations/Availability/Steps/WideAvailabilitySearch/WideAvailabilityPriceProcessor.cs
+++ b/Api/Services/Accommodations/Availability/Steps/WideAvailabilitySearch/WideAvailabilityPriceProcessor.cs
@@ -1,10 +1,8 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Models.Accommodations;
 using HappyTravel.Edo.Api.Models.Agents;
-using HappyTravel.Edo.Api.Services.Agents;
 using HappyTravel.Edo.Api.Services.Markups.Abstractions;
 using HappyTravel.Money.Enums;
 using Microsoft.AspNetCore.Mvc;
@@ -49,7 +47,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                     supplierAccommodationCode: slimAccommodationAvailability.SupplierAccommodationCode,
                     countryHtId: slimAccommodationAvailability.CountryHtId,
                     localityHtId: slimAccommodationAvailability.LocalityHtId,
-                    marketId: slimAccommodationAvailability.MarketId));
+                    marketId: slimAccommodationAvailability.MarketId,
+                    countryCode: slimAccommodationAvailability.CountryCode));
             }
 
             return convertedResults;
@@ -87,7 +86,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                     supplierAccommodationCode: slimAccommodationAvailability.SupplierAccommodationCode,
                     countryHtId: slimAccommodationAvailability.CountryHtId,
                     localityHtId: slimAccommodationAvailability.LocalityHtId,
-                    marketId: slimAccommodationAvailability.MarketId));
+                    marketId: slimAccommodationAvailability.MarketId,
+                    countryCode: slimAccommodationAvailability.CountryCode));
             }
 
             return convertedResults;
@@ -114,7 +114,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                     supplierAccommodationCode: accommodationAvailability.SupplierAccommodationCode,
                     countryHtId: accommodationAvailability.CountryHtId,
                     localityHtId: accommodationAvailability.LocalityHtId,
-                    marketId: accommodationAvailability.MarketId));
+                    marketId: accommodationAvailability.MarketId,
+                    countryCode: accommodationAvailability.CountryCode));
             }
 
             return convertedResults;
@@ -135,7 +136,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                 CountryHtId = availability.CountryHtId,
                 LocalityHtId = availability.LocalityHtId,
                 AccommodationHtId = availability.HtId,
-                MarketId = availability.MarketId
+                MarketId = availability.MarketId,
+                CountryCode = availability.CountryCode
             };
 
 

--- a/Api/Services/Accommodations/Availability/Steps/WideAvailabilitySearch/WideAvailabilitySearchTask.cs
+++ b/Api/Services/Accommodations/Availability/Steps/WideAvailabilitySearch/WideAvailabilitySearchTask.cs
@@ -100,7 +100,7 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
 
             void Publish(EdoContracts.Accommodations.Availability availability)
             {
-                _messageBus.Publish(MessageBusTopics.AvailabilitySearch, new 
+                _messageBus.Publish(MessageBusTopics.AvailabilitySearch, new
                 {
                     SearchId = searchId,
                     SupplierCode = supplier.Code,
@@ -109,12 +109,12 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                     agent.AgencyId
                 });
             }
-            
-            
+
+
             List<AccommodationAvailabilityResult> Convert(EdoContracts.Accommodations.Availability details)
             {
                 var htIdMapping = accommodationCodeMappings
-                    .ToDictionary(m => m.SupplierCode, m => (m.AccommodationHtId, m.CountryHtId, m.LocalityHtId, m.MarketId));
+                    .ToDictionary(m => m.SupplierCode, m => (m.AccommodationHtId, m.CountryHtId, m.LocalityHtId, m.MarketId, m.CountryCode));
 
                 var now = _dateTimeProvider.UtcNow();
                 return details
@@ -145,7 +145,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                             supplierAccommodationCode: accommodationAvailability.AccommodationId,
                             countryHtId: htId.CountryHtId,
                             localityHtId: htId.LocalityHtId,
-                            marketId: htId.MarketId);
+                            marketId: htId.MarketId,
+                            countryCode: htId.CountryCode);
                     })
                     .Where(a => !a.Equals(default) && a.RoomContractSets.Any())
                     .ToList();
@@ -248,8 +249,8 @@ namespace HappyTravel.Edo.Api.Services.Accommodations.Availability.Steps.WideAva
                 return resultedFilter;
             }
         }
-        
-        
+
+
         private readonly IWideAvailabilityPriceProcessor _priceProcessor;
         private readonly ISupplierConnectorManager _supplierConnectorManager;
         private readonly IDateTimeProvider _dateTimeProvider;

--- a/Api/Services/Markups/Abstractions/MarkupDestinationInfo.cs
+++ b/Api/Services/Markups/Abstractions/MarkupDestinationInfo.cs
@@ -6,5 +6,6 @@ namespace HappyTravel.Edo.Api.Services.Markups.Abstractions
         public string LocalityHtId { get; init; }
         public string AccommodationHtId { get; init; }
         public int MarketId { get; init; }
+        public string CountryCode { get; init; }
     }
 }

--- a/Api/Services/Markups/MarkupPolicyService.cs
+++ b/Api/Services/Markups/MarkupPolicyService.cs
@@ -51,8 +51,8 @@ namespace HappyTravel.Edo.Api.Services.Markups
             static bool IsApplicableByObject(MarkupPolicy policy, MarkupDestinationInfo info)
             {
                 var destinationScopeId = policy.DestinationScopeId;
-                return string.IsNullOrWhiteSpace(destinationScopeId) || destinationScopeId == info.MarketId.ToString();
-                /*|| destinationScopeId == info.CountryHtId || destinationScopeId == info.LocalityHtId || destinationScopeId == info.AccommodationHtId;*/
+                return string.IsNullOrWhiteSpace(destinationScopeId) || destinationScopeId == info.MarketId.ToString() ||
+                    destinationScopeId == info.CountryCode; // || destinationScopeId == info.LocalityHtId || destinationScopeId == info.AccommodationHtId;*/
             }
         }
 

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/AdminMarkupPolicyTests/AdminMarkupPolicyManagerTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/AdminMarkupPolicyTests/AdminMarkupPolicyManagerTests.cs
@@ -93,6 +93,18 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.AdminMarkupPolicyTest
 
 
         [Fact]
+        public async Task Add_destination_markup_with_wrong_country_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                null, "GB", null, DestinationMarkupScopeTypes.Country);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
         public async Task Add_location_markup_with_wrong_market_should_return_fail()
         {
             var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/FilterByMarkupDestination.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/FilterByMarkupDestination.cs
@@ -11,43 +11,44 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupPolicyServiceTe
     {
         // This tests will be uncommented at the second stage of work on markups - Issue - AA #1310
 
-        // [Fact]
-        // public void Markups_for_hotel_country_should_be_returned()
-        // {
-        //     var markupSubject = GetDummyMarkupSubject();
+        [Fact]
+        public void Markups_for_hotel_country_should_be_returned()
+        {
+            var markupSubject = GetDummyMarkupSubject();
 
-        //     var markupDestination = new MarkupDestinationInfo
-        //     {
-        //         AccommodationHtId = "President Hotel", 
-        //         CountryHtId = "UAE", 
-        //         LocalityHtId = "Dubai"
-        //     };
+            var markupDestination = new MarkupDestinationInfo
+            {
+                AccommodationHtId = "President Hotel",
+                CountryHtId = "UAE",
+                LocalityHtId = "Dubai",
+                CountryCode = "AE"
+            };
 
-        //     var markupPolicies = new List<MarkupPolicy>
-        //     {
-        //         new()
-        //         {
-        //             Id = 1,
-        //             SubjectScopeType = SubjectMarkupScopeTypes.Global,
-        //             DestinationScopeType = DestinationMarkupScopeTypes.Country,
-        //             DestinationScopeId = "UAE"
-        //         },
-        //         new()
-        //         {
-        //             Id = 2,
-        //             SubjectScopeType = SubjectMarkupScopeTypes.Global,
-        //             DestinationScopeType = DestinationMarkupScopeTypes.Country,
-        //             DestinationScopeId = "Russia"
-        //         }
-        //     };
+            var markupPolicies = new List<MarkupPolicy>
+            {
+                new()
+                {
+                    Id = 1,
+                    SubjectScopeType = SubjectMarkupScopeTypes.Global,
+                    DestinationScopeType = DestinationMarkupScopeTypes.Country,
+                    DestinationScopeId = "AE"
+                },
+                new()
+                {
+                    Id = 2,
+                    SubjectScopeType = SubjectMarkupScopeTypes.Global,
+                    DestinationScopeType = DestinationMarkupScopeTypes.Country,
+                    DestinationScopeId = "RU"
+                }
+            };
 
-        //     var service = MarkupPolicyServiceMock.Create(markupPolicies);
+            var service = MarkupPolicyServiceMock.Create(markupPolicies);
 
-        //     var policies = service.Get(markupSubject, markupDestination);
+            var policies = service.Get(markupSubject, markupDestination);
 
-        //     Assert.Single(policies);
-        //     Assert.Equal(1, policies[0].Id);
-        // }
+            Assert.Single(policies);
+            Assert.Equal(1, policies[0].Id);
+        }
 
 
         // [Fact]
@@ -216,7 +217,8 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupPolicyServiceTe
                 AgencyId = 1,
                 AgentId = 1,
                 CountryHtId = "Russia",
-                LocalityHtId = "Moscow"
+                LocalityHtId = "Moscow",
+                CountryCode = "RU"
             };
     }
 }

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/FilterByMarkupSubject.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/FilterByMarkupSubject.cs
@@ -289,7 +289,8 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupPolicyServiceTe
             {
                 AccommodationHtId = "President Hotel",
                 CountryHtId = "UAE",
-                LocalityHtId = "Dubai"
+                LocalityHtId = "Dubai",
+                CountryCode = "AE"
             };
     }
 }

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/FilterBySubjectAndDestination.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/FilterBySubjectAndDestination.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using HappyTravel.Edo.Api.Services.Agents;
 using HappyTravel.Edo.Api.Services.Markups.Abstractions;
 using HappyTravel.Edo.Common.Enums.Markup;
 using HappyTravel.Edo.Data.Markup;


### PR DESCRIPTION
Issue: https://github.com/happy-travel/agent-app-project/issues/1374
Insomnia: Edo -> Admin -> Markups -> Locations Markups
Tested through unit tests

Test case:
1) Add country destination markup through POST endpoint ../admin/location-markups and check validators
2) Start availability search for hotel from country which markup was added before
3) Check if markup was applied

JSON example:
{
"description": "test",
"functionType": 1,
"value": 20,
"currency": "USD",
"destinationScopeId": "RU",
"destinationScopeType": 2
}