### PR TITLE
Markup according to the country where the hotel is located for a specific root agency

### DIFF
--- a/Api/Services/Markups/AdminMarkupPolicyManager.cs
+++ b/Api/Services/Markups/AdminMarkupPolicyManager.cs
@@ -139,14 +139,14 @@ namespace HappyTravel.Edo.Api.Services.Markups
                             v.RuleFor(m => m.DestinationScopeId)
                                 .NotNull()
                                 .MustAsync(DestinationMarkupDoesNotExist()!)
-                                .When(m => m.DestinationScopeType == DestinationMarkupScopeTypes.Market || m.DestinationScopeType == DestinationMarkupScopeTypes.Country ||
+                                .When(m => (m.DestinationScopeType == DestinationMarkupScopeTypes.Market || m.DestinationScopeType == DestinationMarkupScopeTypes.Country) &&
                                     m.LocationScopeType is null)
                                 .WithMessage(m => $"Destination markup policy with DestinationScopeId {m.DestinationScopeId} already exists or unexpected value!")
                                 .MustAsync(MarketExists()!)
                                 .When(m => m.DestinationScopeType == DestinationMarkupScopeTypes.Market, ApplyConditionTo.CurrentValidator)
                                 .WithMessage(m => $"Market with id {m.DestinationScopeId} doesn't exist!")
                                 .MustAsync(CountryExists()!)
-                                .When(m => m.DestinationScopeType == DestinationMarkupScopeTypes.Country && m.LocationScopeType is null, ApplyConditionTo.CurrentValidator)
+                                .When(m => m.DestinationScopeType == DestinationMarkupScopeTypes.Country, ApplyConditionTo.CurrentValidator)
                                 .WithMessage(m => $"Country with code {m.DestinationScopeId} doesn't exist!");
 
                             v.RuleFor(m => m.DestinationScopeType)

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/AdminMarkupPolicyTests/AdminMarkupPolicyManagerTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/AdminMarkupPolicyTests/AdminMarkupPolicyManagerTests.cs
@@ -225,6 +225,66 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.AdminMarkupPolicyTest
 
 
         [Fact]
+        public async Task Add_agency_destination_country_markup_which_already_exist_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                "1", "KZ", SubjectMarkupScopeTypes.Agency, DestinationMarkupScopeTypes.Country);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Add_agency_destination_country_markup_with_unexpected_type_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                "1", "RU", SubjectMarkupScopeTypes.Agency, DestinationMarkupScopeTypes.Accommodation);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Add_agency_destination_country_markup_with_null_agencyId_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                null, "RU", SubjectMarkupScopeTypes.Agency, DestinationMarkupScopeTypes.Country);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Add_agency_destination_country_markup_with_wrong_agencyId_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                "4", "RU", SubjectMarkupScopeTypes.Agency, DestinationMarkupScopeTypes.Country);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
+        public async Task Add_agency_destination_country_markup_with_wrong_countryCode_should_return_fail()
+        {
+            var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, -1, Currencies.USD,
+                "1", "GB", SubjectMarkupScopeTypes.Agency, DestinationMarkupScopeTypes.Country);
+
+            var (_, isFailure, error) = await _adminMarkupPolicyManager.AddLocationPolicy(settings);
+
+            Assert.True(isFailure);
+        }
+
+
+        [Fact]
         public async Task Modify_location_markup_with_wrong_policyId_should_return_fail()
         {
             var settings = new MarkupPolicySettings("Description", MarkupFunctionType.Percent, 2, Currencies.USD,
@@ -398,14 +458,14 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.AdminMarkupPolicyTest
             new MarkupPolicy
             {
                 Id = 3,
-                Value = 1,
+                Value = -11,
                 Currency = Currencies.USD,
                 FunctionType = MarkupFunctionType.Percent,
                 Description = "Markup 3",
-                SubjectScopeId = string.Empty,
-                SubjectScopeType = SubjectMarkupScopeTypes.Global,
-                DestinationScopeId = "3",
-                DestinationScopeType = DestinationMarkupScopeTypes.Market
+                SubjectScopeId = "1",
+                SubjectScopeType = SubjectMarkupScopeTypes.Agency,
+                DestinationScopeId = "KZ",
+                DestinationScopeType = DestinationMarkupScopeTypes.Country
             },
             new MarkupPolicy
             {

--- a/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/FilterByMarkupDestination.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/Services/Markups/MarkupPolicyServiceTests/FilterByMarkupDestination.cs
@@ -210,6 +210,48 @@ namespace HappyTravel.Edo.UnitTests.Tests.Services.Markups.MarkupPolicyServiceTe
         }
 
 
+        [Fact]
+        public void Markups_specify_agent_for_hotel_country_should_be_returned()
+        {
+            var markupSubject = GetDummyMarkupSubject();
+
+            var markupDestination = new MarkupDestinationInfo
+            {
+                AccommodationHtId = "President Hotel",
+                CountryHtId = "UAE",
+                LocalityHtId = "Dubai",
+                CountryCode = "AE",
+                MarketId = 2
+            };
+
+            var markupPolicies = new List<MarkupPolicy>
+            {
+                new()
+                {
+                    Id = 1,
+                    SubjectScopeId = "1",
+                    SubjectScopeType = SubjectMarkupScopeTypes.Agency,
+                    DestinationScopeType = DestinationMarkupScopeTypes.Country,
+                    DestinationScopeId = "AE"
+                },
+                new()
+                {
+                    Id = 2,
+                    SubjectScopeType = SubjectMarkupScopeTypes.Global,
+                    DestinationScopeType = DestinationMarkupScopeTypes.Country,
+                    DestinationScopeId = "RU"
+                }
+            };
+
+            var service = MarkupPolicyServiceMock.Create(markupPolicies);
+
+            var policies = service.Get(markupSubject, markupDestination);
+
+            Assert.Single(policies);
+            Assert.Equal(1, policies[0].Id);
+        }
+
+
         private MarkupSubjectInfo GetDummyMarkupSubject()
             => new()
             {


### PR DESCRIPTION
Issue: https://github.com/happy-travel/agent-app-project/issues/1375
Insomnia: Edo -> Admin -> Markups -> Locations Markups
Tested through unit tests

Test case:

1) Add agency destination country markup through POST endpoint ../admin/location-markups and check validators
2) Start availability search for hotel from country which markup was added before
3) Check if markup was applied

JSON example:
{
"description": "test",
"functionType": 1,
"value": 5,
"currency": "USD",
"locationScopeId": "1171",
"locationScopeType": 5,
"destinationScopeId": "RU",
"destinationScopeType": 2
}