### PR TITLE
Add accountManagerId to agency info model

### DIFF
--- a/Api/AdministratorServices/AdminAgencyManagementService.cs
+++ b/Api/AdministratorServices/AdminAgencyManagementService.cs
@@ -80,6 +80,9 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                             : markupFormula.DisplayFormula,
                         admin != null ?
                             PersonNameFormatters.ToMaskedName(admin.FirstName, admin.LastName, null) :
+                            null,
+                        admin != null ?
+                            admin.Id :
                             null))
                 .SingleOrDefaultAsync();
 
@@ -144,6 +147,9 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                             : markupFormula.DisplayFormula,
                         admin != null ?
                             PersonNameFormatters.ToMaskedName(admin.FirstName, admin.LastName, null) :
+                            null,
+                        admin != null ?
+                            admin.Id :
                             null))
                 .ToListAsync();
 

--- a/Api/Extensions/AgencyInfoExtensions.cs
+++ b/Api/Extensions/AgencyInfoExtensions.cs
@@ -14,7 +14,7 @@ namespace HappyTravel.Edo.Api.Extensions
     {
         public static AgencyInfo ToAgencyInfo(this Agency agency, ContractKind? contractKind,
             AgencyVerificationStates verificationState, DateTime? verificationDate, MultiLanguage<string> countryNames,
-            string languageCode, string markupFormula, string? accountManagerName)
+            string languageCode, string markupFormula, string? accountManagerName, int? accountManagerId)
             => new AgencyInfo(name: agency.Name,
                 id: agency.Id,
                 address: agency.Address,
@@ -39,6 +39,7 @@ namespace HappyTravel.Edo.Api.Extensions
                 isContractUploaded: agency.IsContractUploaded,
                 markupDisplayFormula: markupFormula,
                 preferredCurrency: agency.PreferredCurrency,
-                accountManagerName: accountManagerName);
+                accountManagerName: accountManagerName,
+                accountManagerId: accountManagerId);
     }
 }

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -2565,6 +2565,11 @@
             Agency preferred currency
             </summary>
         </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agencies.AgencyInfo.AccountManagerId">
+            <summary>
+            Account manager id
+            </summary>
+        </member>
         <member name="P:HappyTravel.Edo.Api.Models.Agencies.AgencyInfo.AccountManagerName">
             <summary>
             Name of the account manager

--- a/Api/Models/Agencies/AgencyInfo.cs
+++ b/Api/Models/Agencies/AgencyInfo.cs
@@ -14,7 +14,7 @@ namespace HappyTravel.Edo.Api.Models.Agencies
             string countryCode, string countryName, string fax, string phone, string postalCode, string website, string vatNumber,
             PaymentTypes defaultPaymentType, string countryHtId, string localityHtId, List<int> ancestors,
             AgencyVerificationStates verificationState, DateTime? verificationDate, bool isActive, string legalAddress, PaymentTypes preferredPaymentMethod,
-            bool isContractUploaded, string markupDisplayFormula, Currencies preferredCurrency, string? accountManagerName)
+            bool isContractUploaded, string markupDisplayFormula, Currencies preferredCurrency, string? accountManagerName, int? accountManagerId)
         {
             Name = name;
             Id = id;
@@ -41,6 +41,7 @@ namespace HappyTravel.Edo.Api.Models.Agencies
             MarkupDisplayFormula = markupDisplayFormula;
             PreferredCurrency = preferredCurrency;
             AccountManagerName = accountManagerName;
+            AccountManagerId = accountManagerId;
         }
 
 
@@ -169,6 +170,10 @@ namespace HappyTravel.Edo.Api.Models.Agencies
         /// </summary>
         public Currencies PreferredCurrency { get; }
 
+        /// <summary>
+        /// Account manager id
+        /// </summary>
+        public int? AccountManagerId { get; }
 
         /// <summary>
         /// Name of the account manager

--- a/Api/Services/Agents/AgencyService.cs
+++ b/Api/Services/Agents/AgencyService.cs
@@ -183,6 +183,9 @@ namespace HappyTravel.Edo.Api.Services.Agents
                             : markupFormula.DisplayFormula,
                         admin != null ?
                             PersonNameFormatters.ToMaskedName(admin.FirstName, admin.LastName, null) :
+                            null,
+                        admin != null ?
+                            admin.Id :
                             null))
                 .SingleOrDefaultAsync();
 


### PR DESCRIPTION
Account manager id was added to model AgencyInfo

Tested through insomnia:

- /en/api/1.0/admin/agencies/:agencyId
- /en/api/1.0/admin/agencies/:agencyId/child-agencies