### PR TITLE
Feature/aa 1628 add credit limit to agency

### DIFF
--- a/Api/AdministratorServices/AgencyVerificationService.cs
+++ b/Api/AdministratorServices/AgencyVerificationService.cs
@@ -45,7 +45,6 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                 .Ensure(a => a.ParentId is null, "Verification is only available for root agencies")
                 .Ensure(a => a.VerificationState == AgencyVerificationStates.ReadOnly,
                     "Verification as fully accessed is only available for agencies that were verified as read-only earlier")
-                .Ensure(IsContractKindNotEmpty, "Contract kind must be not empty")
                 .Tap(c => SetVerificationState(c, AgencyVerificationStates.FullAccess, request.Reason))
                 .Tap(SetContractKind)
                 .Tap(SetAprModeAndPassedDeadlineOffersMode)
@@ -65,10 +64,6 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                         v.RuleFor(r => r.ContractKind)
                             .NotEmpty();
                     }, request);
-
-
-            bool IsContractKindNotEmpty(Agency _)
-                => !request.ContractKind.Equals(default(ContractKind));
 
 
             async Task SetContractKind(Agency agency)

--- a/Api/AdministratorServices/IAdminAgencyManagementService.cs
+++ b/Api/AdministratorServices/IAdminAgencyManagementService.cs
@@ -28,7 +28,7 @@ namespace HappyTravel.Edo.Api.AdministratorServices
 
         Task<Result<ContractKind>> GetContractKind(int agencyId);
 
-        Task<Result> ChangeContractKind(ContractKindChangeRequest request);
+        Task<Result> ChangeContractKind(int agencyId, ContractKindChangeRequest request);
 
         Task<Result<AgencyVerificationStates>> GetVerificationState(int agencyId);
 

--- a/Api/AdministratorServices/IAdminAgencyManagementService.cs
+++ b/Api/AdministratorServices/IAdminAgencyManagementService.cs
@@ -6,6 +6,7 @@ using CSharpFunctionalExtensions;
 using HappyTravel.Edo.Api.Infrastructure;
 using HappyTravel.Edo.Api.Models.Agencies;
 using HappyTravel.Edo.Api.Models.Locations;
+using HappyTravel.Edo.Api.Models.Management;
 using HappyTravel.Edo.Common.Enums;
 using HappyTravel.Edo.Data.Agents;
 
@@ -27,7 +28,7 @@ namespace HappyTravel.Edo.Api.AdministratorServices
 
         Task<Result<ContractKind>> GetContractKind(int agencyId);
 
-        Task<Result> ChangeContractKind(int agencyId, ContractKind contractKind, string reason);
+        Task<Result> ChangeContractKind(ContractKindChangeRequest request);
 
         Task<Result<AgencyVerificationStates>> GetVerificationState(int agencyId);
 

--- a/Api/AdministratorServices/IAgencyVerificationService.cs
+++ b/Api/AdministratorServices/IAgencyVerificationService.cs
@@ -1,12 +1,14 @@
 ﻿using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Models.Management;
 using HappyTravel.Edo.Data.Agents;
+using HappyTravel.Money.Models;
 
 namespace HappyTravel.Edo.Api.AdministratorServices
 {
     public interface IAgencyVerificationService
     {
-        Task<Result> VerifyAsFullyAccessed(int agencyId, ContractKind contractKind, string verificationReason);
+        Task<Result> VerifyAsFullyAccessed(AgencyFullAccessVerificationRequest request);
         Task<Result> VerifyAsReadOnly(int agencyId, string verificationReason);
         Task<Result> DeclineVerification(int agencyId, string verificationReason);
     }

--- a/Api/AdministratorServices/IAgencyVerificationService.cs
+++ b/Api/AdministratorServices/IAgencyVerificationService.cs
@@ -8,7 +8,7 @@ namespace HappyTravel.Edo.Api.AdministratorServices
 {
     public interface IAgencyVerificationService
     {
-        Task<Result> VerifyAsFullyAccessed(AgencyFullAccessVerificationRequest request);
+        Task<Result> VerifyAsFullyAccessed(int agencyId, AgencyFullAccessVerificationRequest request);
         Task<Result> VerifyAsReadOnly(int agencyId, string verificationReason);
         Task<Result> DeclineVerification(int agencyId, string verificationReason);
     }

--- a/Api/Controllers/AdministratorControllers/AgenciesController.cs
+++ b/Api/Controllers/AdministratorControllers/AgenciesController.cs
@@ -213,7 +213,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         [AdministratorPermissions(AdministratorPermissions.AgencyVerification)]
         public async Task<IActionResult> VerifyFullAccess(int agencyId, [FromBody] AgencyFullAccessVerificationRequest request)
         {
-            var (isSuccess, _, error) = await _agencyVerificationService.VerifyAsFullyAccessed(agencyId, request.ContractKind, request.Reason);
+            var (isSuccess, _, error) = await _agencyVerificationService
+                .VerifyAsFullyAccessed(new AgencyFullAccessVerificationRequest(agencyId, request));
 
             return isSuccess
                 ? (IActionResult)NoContent()
@@ -317,7 +318,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
             var query = opts.ApplyTo(_agencyManagementService.GetRootAgencies(LanguageCode), AllowedQueryOptions.Skip | AllowedQueryOptions.Top);
             var count = await query.Cast<AdminViewAgencyInfo>().CountAsync();
             HttpContext.Response.Headers.Add(CountHeader, count.ToString());
-            
+
             return _agencyManagementService.GetRootAgencies(LanguageCode);
         }
 

--- a/Api/Controllers/AdministratorControllers/AgenciesController.cs
+++ b/Api/Controllers/AdministratorControllers/AgenciesController.cs
@@ -213,8 +213,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         [AdministratorPermissions(AdministratorPermissions.AgencyVerification)]
         public async Task<IActionResult> VerifyFullAccess(int agencyId, [FromBody] AgencyFullAccessVerificationRequest request)
         {
-            var (isSuccess, _, error) = await _agencyVerificationService
-                .VerifyAsFullyAccessed(new AgencyFullAccessVerificationRequest(agencyId, request));
+            var (isSuccess, _, error) = await _agencyVerificationService.VerifyAsFullyAccessed(agencyId, request);
 
             return isSuccess
                 ? (IActionResult)NoContent()
@@ -335,8 +334,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.AgencyManagement)]
         public async Task<IActionResult> ChangeContractKind(int agencyId, [FromBody] ContractKindChangeRequest request)
-            => NoContentOrBadRequest(await _agencyManagementService
-                .ChangeContractKind(new ContractKindChangeRequest(agencyId, request)));
+            => NoContentOrBadRequest(await _agencyManagementService.ChangeContractKind(agencyId, request));
 
 
         [HttpPut("locality/fulfill")]

--- a/Api/Controllers/AdministratorControllers/AgenciesController.cs
+++ b/Api/Controllers/AdministratorControllers/AgenciesController.cs
@@ -335,7 +335,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.AgencyManagement)]
         public async Task<IActionResult> ChangeContractKind(int agencyId, [FromBody] ContractKindChangeRequest request)
-            => NoContentOrBadRequest(await _agencyManagementService.ChangeContractKind(agencyId, request.ContractKind, request.Reason));
+            => NoContentOrBadRequest(await _agencyManagementService
+                .ChangeContractKind(new ContractKindChangeRequest(agencyId, request)));
 
 
         [HttpPut("locality/fulfill")]

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -3573,6 +3573,11 @@
                 Verify reason.
             </summary>
         </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Management.ContractKindChangeRequest.AgencyId">
+            <summary>
+            Agency Id
+            </summary>
+        </member>
         <member name="P:HappyTravel.Edo.Api.Models.Management.ContractKindChangeRequest.ContractKind">
             <summary>
             Contract type
@@ -3581,6 +3586,11 @@
         <member name="P:HappyTravel.Edo.Api.Models.Management.ContractKindChangeRequest.Reason">
             <summary>
             Verify reason.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Management.ContractKindChangeRequest.CreditLimit">
+            <summary>
+            Credit limit required when Contract type equals VirtualAccountOrCreditCardPayments.
             </summary>
         </member>
         <member name="P:HappyTravel.Edo.Api.Models.Management.ManualBookingCancellationRequest.CancellationDate">

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -3548,6 +3548,11 @@
                 Verify reason.
             </summary>
         </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Management.AgencyFullAccessVerificationRequest.AgencyId">
+            <summary>
+            AgencyId
+            </summary>
+        </member>
         <member name="P:HappyTravel.Edo.Api.Models.Management.AgencyFullAccessVerificationRequest.ContractKind">
             <summary>
             Contract type
@@ -3556,6 +3561,11 @@
         <member name="P:HappyTravel.Edo.Api.Models.Management.AgencyFullAccessVerificationRequest.Reason">
             <summary>
             Verify reason.
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Management.AgencyFullAccessVerificationRequest.CreditLimit">
+            <summary>
+            Credit limit required when Contract type equals VirtualAccountOrCreditCardPayments.
             </summary>
         </member>
         <member name="P:HappyTravel.Edo.Api.Models.Management.AgencyReadOnlyVerificationRequest.Reason">

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -3548,11 +3548,6 @@
                 Verify reason.
             </summary>
         </member>
-        <member name="P:HappyTravel.Edo.Api.Models.Management.AgencyFullAccessVerificationRequest.AgencyId">
-            <summary>
-            AgencyId
-            </summary>
-        </member>
         <member name="P:HappyTravel.Edo.Api.Models.Management.AgencyFullAccessVerificationRequest.ContractKind">
             <summary>
             Contract type
@@ -3571,11 +3566,6 @@
         <member name="P:HappyTravel.Edo.Api.Models.Management.AgencyReadOnlyVerificationRequest.Reason">
             <summary>
                 Verify reason.
-            </summary>
-        </member>
-        <member name="P:HappyTravel.Edo.Api.Models.Management.ContractKindChangeRequest.AgencyId">
-            <summary>
-            Agency Id
             </summary>
         </member>
         <member name="P:HappyTravel.Edo.Api.Models.Management.ContractKindChangeRequest.ContractKind">

--- a/Api/Models/Management/AgencyFullAccessVerificationRequest.cs
+++ b/Api/Models/Management/AgencyFullAccessVerificationRequest.cs
@@ -8,25 +8,14 @@ namespace HappyTravel.Edo.Api.Models.Management
     public readonly struct AgencyFullAccessVerificationRequest
     {
         [JsonConstructor]
-        public AgencyFullAccessVerificationRequest(int? agencyId, ContractKind contractKind,
+        public AgencyFullAccessVerificationRequest(ContractKind contractKind,
             string reason, MoneyAmount? creditLimit)
         {
-            AgencyId = agencyId;
             ContractKind = contractKind;
             Reason = reason;
             CreditLimit = creditLimit;
         }
 
-
-        public AgencyFullAccessVerificationRequest(int? agencyId, AgencyFullAccessVerificationRequest request)
-            : this(agencyId, request.ContractKind, request.Reason, request.CreditLimit)
-        { }
-
-
-        /// <summary>
-        /// AgencyId
-        /// </summary>
-        public int? AgencyId { get; }
 
         /// <summary>
         /// Contract type

--- a/Api/Models/Management/AgencyFullAccessVerificationRequest.cs
+++ b/Api/Models/Management/AgencyFullAccessVerificationRequest.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using HappyTravel.Edo.Data.Agents;
+using HappyTravel.Money.Models;
 using Newtonsoft.Json;
 
 namespace HappyTravel.Edo.Api.Models.Management
@@ -7,12 +8,25 @@ namespace HappyTravel.Edo.Api.Models.Management
     public readonly struct AgencyFullAccessVerificationRequest
     {
         [JsonConstructor]
-        public AgencyFullAccessVerificationRequest(ContractKind contractKind, string reason)
+        public AgencyFullAccessVerificationRequest(int? agencyId, ContractKind contractKind,
+            string reason, MoneyAmount? creditLimit)
         {
+            AgencyId = agencyId;
             ContractKind = contractKind;
             Reason = reason;
+            CreditLimit = creditLimit;
         }
 
+
+        public AgencyFullAccessVerificationRequest(int? agencyId, AgencyFullAccessVerificationRequest request)
+            : this(agencyId, request.ContractKind, request.Reason, request.CreditLimit)
+        { }
+
+
+        /// <summary>
+        /// AgencyId
+        /// </summary>
+        public int? AgencyId { get; }
 
         /// <summary>
         /// Contract type
@@ -25,5 +39,10 @@ namespace HappyTravel.Edo.Api.Models.Management
         /// </summary>
         [Required]
         public string Reason { get; }
+
+        /// <summary>
+        /// Credit limit required when Contract type equals VirtualAccountOrCreditCardPayments.
+        /// </summary>
+        public MoneyAmount? CreditLimit { get; }
     }
 }

--- a/Api/Models/Management/ContractKindChangeRequest.cs
+++ b/Api/Models/Management/ContractKindChangeRequest.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using HappyTravel.Edo.Data.Agents;
 using HappyTravel.Money.Models;
 
@@ -6,25 +7,15 @@ namespace HappyTravel.Edo.Api.Models.Management;
 
 public readonly struct ContractKindChangeRequest
 {
-    public ContractKindChangeRequest(int? agencyId, ContractKind contractKind,
+    [JsonConstructor]
+    public ContractKindChangeRequest(ContractKind contractKind,
             string reason, MoneyAmount? creditLimit)
     {
-        AgencyId = agencyId;
         ContractKind = contractKind;
         Reason = reason;
         CreditLimit = creditLimit;
     }
 
-
-    public ContractKindChangeRequest(int? agencyId, ContractKindChangeRequest request)
-        : this(agencyId, request.ContractKind, request.Reason, request.CreditLimit)
-    { }
-
-
-    /// <summary>
-    /// Agency Id
-    /// </summary>
-    public int? AgencyId { get; }
 
     /// <summary>
     /// Contract type

--- a/Api/Models/Management/ContractKindChangeRequest.cs
+++ b/Api/Models/Management/ContractKindChangeRequest.cs
@@ -1,17 +1,31 @@
 using System.ComponentModel.DataAnnotations;
 using HappyTravel.Edo.Data.Agents;
+using HappyTravel.Money.Models;
 
 namespace HappyTravel.Edo.Api.Models.Management;
 
 public readonly struct ContractKindChangeRequest
 {
-    public ContractKindChangeRequest(ContractKind contractKind, string reason)
+    public ContractKindChangeRequest(int? agencyId, ContractKind contractKind,
+            string reason, MoneyAmount? creditLimit)
     {
+        AgencyId = agencyId;
         ContractKind = contractKind;
         Reason = reason;
+        CreditLimit = creditLimit;
     }
-    
-    
+
+
+    public ContractKindChangeRequest(int? agencyId, ContractKindChangeRequest request)
+        : this(agencyId, request.ContractKind, request.Reason, request.CreditLimit)
+    { }
+
+
+    /// <summary>
+    /// Agency Id
+    /// </summary>
+    public int? AgencyId { get; }
+
     /// <summary>
     /// Contract type
     /// </summary>
@@ -23,4 +37,9 @@ public readonly struct ContractKindChangeRequest
     /// </summary>
     [Required]
     public string Reason { get; }
+
+    /// <summary>
+    /// Credit limit required when Contract type equals VirtualAccountOrCreditCardPayments.
+    /// </summary>
+    public MoneyAmount? CreditLimit { get; }
 }

--- a/HappyTravel.Edo.Data/Agents/Agency.cs
+++ b/HappyTravel.Edo.Data/Agents/Agency.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using HappyTravel.Edo.Common.Enums;
 using HappyTravel.Money.Enums;
+using HappyTravel.Money.Models;
 
 namespace HappyTravel.Edo.Data.Agents
 {
@@ -34,5 +35,6 @@ namespace HappyTravel.Edo.Data.Agents
         public PaymentTypes PreferredPaymentMethod { get; set; }
         public bool IsContractUploaded { get; set; }
         public int? AccountManagerId { get; set; }
+        public MoneyAmount? CreditLimit { get; set; }
     }
 }

--- a/HappyTravel.Edo.Data/EdoContext.cs
+++ b/HappyTravel.Edo.Data/EdoContext.cs
@@ -308,6 +308,7 @@ namespace HappyTravel.Edo.Data
                 agency.Property(a => a.VerificationState).IsRequired().HasDefaultValue(AgencyVerificationStates.PendingVerification);
                 agency.Property(a => a.PreferredPaymentMethod).IsRequired();
                 agency.Property(a => a.LegalAddress).IsRequired();
+                agency.Property(b => b.CreditLimit).HasColumnType("jsonb");
             });
         }
 

--- a/HappyTravel.Edo.Data/Migrations/20220728055740_AddCreditLimitToAgency.Designer.cs
+++ b/HappyTravel.Edo.Data/Migrations/20220728055740_AddCreditLimitToAgency.Designer.cs
@@ -9,6 +9,7 @@ using HappyTravel.Money.Models;
 using HappyTravel.MultiLanguage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -17,9 +18,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HappyTravel.Edo.Data.Migrations
 {
     [DbContext(typeof(EdoContext))]
-    partial class EdoContextModelSnapshot : ModelSnapshot
+    [Migration("20220728055740_AddCreditLimitToAgency")]
+    partial class AddCreditLimitToAgency
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HappyTravel.Edo.Data/Migrations/20220728055740_AddCreditLimitToAgency.cs
+++ b/HappyTravel.Edo.Data/Migrations/20220728055740_AddCreditLimitToAgency.cs
@@ -1,0 +1,26 @@
+﻿using HappyTravel.Money.Models;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HappyTravel.Edo.Data.Migrations
+{
+    public partial class AddCreditLimitToAgency : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<MoneyAmount>(
+                name: "CreditLimit",
+                table: "Agencies",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreditLimit",
+                table: "Agencies");
+        }
+    }
+}

--- a/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/AgencyVerificationServiceTests/AgencyVerificationTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/AgencyVerificationServiceTests/AgencyVerificationTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.Models.Management;
 using HappyTravel.Edo.Common.Enums;
 using HappyTravel.Edo.Data.Agents;
 using HappyTravel.Edo.UnitTests.Utility;
@@ -24,7 +25,8 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices.AgencyVerificati
             var context = _administratorServicesMockCreationHelper.GetContextMock().Object;
             var agencyVerificationService = _administratorServicesMockCreationHelper.GetAgencyVerificationService(context);
 
-            var (_, isFailure, error) = await agencyVerificationService.VerifyAsFullyAccessed(7, ContractKind.OfflineOrCreditCardPayments, "Test reason");
+            var (_, isFailure, error) = await agencyVerificationService
+                .VerifyAsFullyAccessed(new AgencyFullAccessVerificationRequest(7, ContractKind.OfflineOrCreditCardPayments, "Test reason", null));
 
             Assert.True(isFailure);
         }
@@ -48,28 +50,30 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices.AgencyVerificati
             var context = _administratorServicesMockCreationHelper.GetContextMock().Object;
             var agencyVerificationService = _administratorServicesMockCreationHelper.GetAgencyVerificationService(context);
 
-            var (_, isFailure, _) = await agencyVerificationService.VerifyAsFullyAccessed(20, ContractKind.OfflineOrCreditCardPayments, "Test reason");
+            var (_, isFailure, _) = await agencyVerificationService
+                .VerifyAsFullyAccessed(new AgencyFullAccessVerificationRequest(20, ContractKind.OfflineOrCreditCardPayments, "Test reason", null));
 
             var agency = context.Agencies.Single(c => c.Id == 20);
             Assert.False(isFailure);
             Assert.True(agency.VerificationState == AgencyVerificationStates.FullAccess && agency.VerificationReason.Contains("Test reason"));
         }
-        
-        
+
+
         [Fact]
         public async Task Verification_as_full_accessed_for_not_verified_read_only_should_fail()
         {
             var context = _administratorServicesMockCreationHelper.GetContextMock().Object;
             var agencyVerificationService = _administratorServicesMockCreationHelper.GetAgencyVerificationService(context);
 
-            var (_, isFailure, _) = await agencyVerificationService.VerifyAsFullyAccessed(3, ContractKind.OfflineOrCreditCardPayments, "Test reason");
+            var (_, isFailure, _) = await agencyVerificationService
+                .VerifyAsFullyAccessed(new AgencyFullAccessVerificationRequest(3, ContractKind.OfflineOrCreditCardPayments, "Test reason", null));
 
             var agency = context.Agencies.Single(c => c.Id == 3);
             Assert.True(isFailure);
             Assert.True(agency.VerificationState == AgencyVerificationStates.PendingVerification);
         }
-        
-        
+
+
         [Fact]
         public async Task Verification_as_read_only_for_full_accessed_agency_should_fail()
         {
@@ -106,20 +110,21 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices.AgencyVerificati
 
             var (_, isFailure, error) = await agencyVerificationService.VerifyAsReadOnly(1, "Test reason");
 
-            var agencies = new List<int> {1, 2, 4};
+            var agencies = new List<int> { 1, 2, 4 };
             Assert.False(isFailure);
             Assert.Equal(5, context.AgencyAccounts.ToList().Count);
             Assert.True(agencies.All(a => context.AgencyAccounts.Any(ac => ac.AgencyId == a)));
         }
-        
-        
+
+
         [Fact]
         public async Task Full_access_verification_with_empty_contract_type_must_fail()
         {
             var context = _administratorServicesMockCreationHelper.GetContextMock().Object;
             var agencyVerificationService = _administratorServicesMockCreationHelper.GetAgencyVerificationService(context);
 
-            var (_, isFailure, _) = await agencyVerificationService.VerifyAsFullyAccessed(14, default, "Test reason");
+            var (_, isFailure, _) = await agencyVerificationService
+                .VerifyAsFullyAccessed(new AgencyFullAccessVerificationRequest(14, default, "Test reason", null));
 
             Assert.True(isFailure);
         }
@@ -133,7 +138,8 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices.AgencyVerificati
             var context = _administratorServicesMockCreationHelper.GetContextMock().Object;
             var agencyVerificationService = _administratorServicesMockCreationHelper.GetAgencyVerificationService(context);
 
-            await agencyVerificationService.VerifyAsFullyAccessed(20, contractKind, "Test reason");
+            await agencyVerificationService
+                .VerifyAsFullyAccessed(new AgencyFullAccessVerificationRequest(20, contractKind, "Test reason", null));
 
             Assert.Equal(contractKind, context.Agencies.Single(c => c.Id == 20).ContractKind);
         }

--- a/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/AgencyVerificationServiceTests/AgencyVerificationTests.cs
+++ b/HappyTravel.Edo.UnitTests/Tests/AdministratorServices/AgencyVerificationServiceTests/AgencyVerificationTests.cs
@@ -26,7 +26,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices.AgencyVerificati
             var agencyVerificationService = _administratorServicesMockCreationHelper.GetAgencyVerificationService(context);
 
             var (_, isFailure, error) = await agencyVerificationService
-                .VerifyAsFullyAccessed(new AgencyFullAccessVerificationRequest(7, ContractKind.OfflineOrCreditCardPayments, "Test reason", null));
+                .VerifyAsFullyAccessed(7, new AgencyFullAccessVerificationRequest(ContractKind.OfflineOrCreditCardPayments, "Test reason", null));
 
             Assert.True(isFailure);
         }
@@ -51,7 +51,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices.AgencyVerificati
             var agencyVerificationService = _administratorServicesMockCreationHelper.GetAgencyVerificationService(context);
 
             var (_, isFailure, _) = await agencyVerificationService
-                .VerifyAsFullyAccessed(new AgencyFullAccessVerificationRequest(20, ContractKind.OfflineOrCreditCardPayments, "Test reason", null));
+                .VerifyAsFullyAccessed(20, new AgencyFullAccessVerificationRequest(ContractKind.OfflineOrCreditCardPayments, "Test reason", null));
 
             var agency = context.Agencies.Single(c => c.Id == 20);
             Assert.False(isFailure);
@@ -66,7 +66,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices.AgencyVerificati
             var agencyVerificationService = _administratorServicesMockCreationHelper.GetAgencyVerificationService(context);
 
             var (_, isFailure, _) = await agencyVerificationService
-                .VerifyAsFullyAccessed(new AgencyFullAccessVerificationRequest(3, ContractKind.OfflineOrCreditCardPayments, "Test reason", null));
+                .VerifyAsFullyAccessed(3, new AgencyFullAccessVerificationRequest(ContractKind.OfflineOrCreditCardPayments, "Test reason", null));
 
             var agency = context.Agencies.Single(c => c.Id == 3);
             Assert.True(isFailure);
@@ -124,7 +124,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices.AgencyVerificati
             var agencyVerificationService = _administratorServicesMockCreationHelper.GetAgencyVerificationService(context);
 
             var (_, isFailure, _) = await agencyVerificationService
-                .VerifyAsFullyAccessed(new AgencyFullAccessVerificationRequest(14, default, "Test reason", null));
+                .VerifyAsFullyAccessed(14, new AgencyFullAccessVerificationRequest(default, "Test reason", null));
 
             Assert.True(isFailure);
         }
@@ -139,7 +139,7 @@ namespace HappyTravel.Edo.UnitTests.Tests.AdministratorServices.AgencyVerificati
             var agencyVerificationService = _administratorServicesMockCreationHelper.GetAgencyVerificationService(context);
 
             await agencyVerificationService
-                .VerifyAsFullyAccessed(new AgencyFullAccessVerificationRequest(20, contractKind, "Test reason", null));
+                .VerifyAsFullyAccessed(20, new AgencyFullAccessVerificationRequest(contractKind, "Test reason", null));
 
             Assert.Equal(contractKind, context.Agencies.Single(c => c.Id == 20).ContractKind);
         }


### PR DESCRIPTION
Issue: https://github.com/happy-travel/agent-app-project/issues/1628
Insomnia: Edo -> Admin -> Agencies
Not tested yet

Test cases:
 1) Fully verify new agency with ContractKind = VirtualAccountOrCreditCardPayments, check if CreditLimit is required
 2) Change ContractKind in existing agency to VirtualAccountOrCreditCardPayments, check if CreditLimit is required