### PR TITLE
CreditLimit field was added to Api models

### DIFF
--- a/Api/AdministratorServices/AdminAgencyManagementService.cs
+++ b/Api/AdministratorServices/AdminAgencyManagementService.cs
@@ -117,7 +117,8 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                     VerificationState = agency.VerificationState,
                     AccountManagerId = admin != null ? admin.Id : null,
                     AccountManagerName = admin != null ? PersonNameFormatters.ToMaskedName(admin.FirstName, admin.LastName, null) : null,
-                    IsActive = agency.IsActive
+                    IsActive = agency.IsActive,
+                    CreditLimit = agency.CreditLimit
                 });
 
 

--- a/Api/Extensions/AgencyInfoExtensions.cs
+++ b/Api/Extensions/AgencyInfoExtensions.cs
@@ -40,7 +40,8 @@ namespace HappyTravel.Edo.Api.Extensions
                 markupDisplayFormula: markupFormula,
                 preferredCurrency: agency.PreferredCurrency,
                 accountManagerName: accountManagerName,
-                accountManagerId: accountManagerId, 
-                contractKind: agency.ContractKind);
+                accountManagerId: accountManagerId,
+                contractKind: agency.ContractKind,
+                creditLimit: agency.CreditLimit);
     }
 }

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -2457,6 +2457,11 @@
             Account manager full name
             </summary>
         </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agencies.AdminViewAgencyInfo.CreditLimit">
+            <summary>
+            Agencies credit limit
+            </summary>
+        </member>
         <member name="P:HappyTravel.Edo.Api.Models.Agencies.AdminViewAgencyInfo.Created">
             <summary>
             Agency creation date
@@ -2610,6 +2615,11 @@
         <member name="P:HappyTravel.Edo.Api.Models.Agencies.AgencyInfo.ContractKind">
             <summary>
             Contract kind of the agency
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agencies.AgencyInfo.CreditLimit">
+            <summary>
+            Agencies credit limit
             </summary>
         </member>
         <member name="P:HappyTravel.Edo.Api.Models.Agencies.ChildAgencyInfo.Id">
@@ -2900,6 +2910,11 @@
         <member name="P:HappyTravel.Edo.Api.Models.Agencies.SlimAgencyInfo.IsContractUploaded">
             <summary>
             True if contract is loaded to agency
+            </summary>
+        </member>
+        <member name="P:HappyTravel.Edo.Api.Models.Agencies.SlimAgencyInfo.CreditLimit">
+            <summary>
+            Agencies credit limit
             </summary>
         </member>
         <member name="P:HappyTravel.Edo.Api.Models.Agencies.SlimChildAgencyInfo.Id">

--- a/Api/Models/Agencies/AdminViewAgencyInfo.cs
+++ b/Api/Models/Agencies/AdminViewAgencyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Api.Models.Management.Administrators;
 using HappyTravel.Edo.Common.Enums;
+using HappyTravel.Money.Models;
 
 namespace HappyTravel.Edo.Api.Models.Agencies
 {
@@ -45,6 +46,11 @@ namespace HappyTravel.Edo.Api.Models.Agencies
         /// Account manager full name
         /// </summary>
         public string? AccountManagerName { get; init; }
+
+        /// <summary>
+        /// Agencies credit limit
+        /// </summary>
+        public MoneyAmount? CreditLimit { get; init; }
 
         /// <summary>
         /// Agency creation date

--- a/Api/Models/Agencies/AgencyInfo.cs
+++ b/Api/Models/Agencies/AgencyInfo.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using HappyTravel.Edo.Common.Enums;
 using HappyTravel.Edo.Data.Agents;
 using HappyTravel.Money.Enums;
+using HappyTravel.Money.Models;
 using Newtonsoft.Json;
 
 namespace HappyTravel.Edo.Api.Models.Agencies
@@ -15,7 +16,8 @@ namespace HappyTravel.Edo.Api.Models.Agencies
             string countryCode, string countryName, string fax, string phone, string postalCode, string website, string vatNumber,
             PaymentTypes defaultPaymentType, string countryHtId, string localityHtId, List<int> ancestors,
             AgencyVerificationStates verificationState, DateTime? verificationDate, bool isActive, string legalAddress, PaymentTypes preferredPaymentMethod,
-            bool isContractUploaded, string markupDisplayFormula, Currencies preferredCurrency, string? accountManagerName, int? accountManagerId, ContractKind? contractKind)
+            bool isContractUploaded, string markupDisplayFormula, Currencies preferredCurrency, string? accountManagerName, int? accountManagerId,
+            ContractKind? contractKind, MoneyAmount? creditLimit)
         {
             Name = name;
             Id = id;
@@ -44,6 +46,7 @@ namespace HappyTravel.Edo.Api.Models.Agencies
             AccountManagerName = accountManagerName;
             AccountManagerId = accountManagerId;
             ContractKind = contractKind;
+            CreditLimit = creditLimit;
         }
 
 
@@ -181,11 +184,16 @@ namespace HappyTravel.Edo.Api.Models.Agencies
         /// Name of the account manager
         /// </summary>
         public string? AccountManagerName { get; }
-        
+
         /// <summary>
         /// Contract kind of the agency
         /// </summary>
         public ContractKind? ContractKind { get; }
+
+        /// <summary>
+        /// Agencies credit limit
+        /// </summary>
+        public MoneyAmount? CreditLimit { get; }
 
 
         public override int GetHashCode()

--- a/Api/Models/Agencies/SlimAgencyInfo.cs
+++ b/Api/Models/Agencies/SlimAgencyInfo.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using HappyTravel.Edo.Common.Enums;
+using HappyTravel.Money.Models;
 using Newtonsoft.Json;
 
 namespace HappyTravel.Edo.Api.Models.Agencies
@@ -10,10 +11,10 @@ namespace HappyTravel.Edo.Api.Models.Agencies
     {
         [JsonConstructor]
         public SlimAgencyInfo(string name, string address, string billingEmail, string city,
-            string countryCode, string countryName, string fax, string phone, string postalCode, string website, 
+            string countryCode, string countryName, string fax, string phone, string postalCode, string website,
             string vatNumber, PaymentTypes defaultPaymentType, List<int> ancestors, string countryHtId, string localityHtId,
             AgencyVerificationStates verificationState, DateTime? verificationDate, string legalAddress, PaymentTypes preferredPaymentMethod,
-            bool isContractUploaded)
+            bool isContractUploaded, MoneyAmount? creditLimit)
         {
             Name = name;
             Address = address;
@@ -35,6 +36,7 @@ namespace HappyTravel.Edo.Api.Models.Agencies
             LegalAddress = legalAddress;
             PreferredPaymentMethod = preferredPaymentMethod;
             IsContractUploaded = isContractUploaded;
+            CreditLimit = creditLimit;
         }
 
 
@@ -101,17 +103,17 @@ namespace HappyTravel.Edo.Api.Models.Agencies
         /// Default payment type
         /// </summary>
         public PaymentTypes DefaultPaymentType { get; }
-        
+
         /// <summary>
         /// List of ancestors ids
         /// </summary>
         public List<int> Ancestors { get; }
-        
+
         /// <summary>
         /// Country of agency
         /// </summary>
         public string CountryHtId { get; }
-        
+
         /// <summary>
         /// Locality of agency
         /// </summary>
@@ -142,5 +144,10 @@ namespace HappyTravel.Edo.Api.Models.Agencies
         /// True if contract is loaded to agency
         /// </summary>
         public bool IsContractUploaded { get; }
+
+        /// <summary>
+        /// Agencies credit limit
+        /// </summary>
+        public MoneyAmount? CreditLimit { get; }
     }
 }

--- a/Api/Services/Agents/AgencyService.cs
+++ b/Api/Services/Agents/AgencyService.cs
@@ -116,7 +116,8 @@ namespace HappyTravel.Edo.Api.Services.Agents
                     verificationDate: agencyInfo.VerificationDate,
                     legalAddress: agencyInfo.LegalAddress,
                     preferredPaymentMethod: agencyInfo.PreferredPaymentMethod,
-                    isContractUploaded: agencyInfo.IsContractUploaded));
+                    isContractUploaded: agencyInfo.IsContractUploaded,
+                    creditLimit: agencyInfo.CreditLimit));
         }
 
 


### PR DESCRIPTION
Issue: https://github.com/happy-travel/agent-app-project/issues/1655
Insomnia: Edo -> Admin -> Agencies; Edo -> Agent -> Agencies;
Tested through insomnia

CreditLimit field was added to following endpoint's returning models:
api/{v:apiVersion}/admin/agencies/{agencyId} GET
api/{v:apiVersion}/admin/agencies/{agencyId} PUT
api/{v:apiVersion}/admin/agencies/{agencyId}/child-agencies
api/{v:apiVersion}/admin/agencies/root-agencies

api/{v:apiVersion}/agency GET
api/{v:apiVersion}/agency PUT