### PR TITLE
Add endpoint to fix accommodation id in bookings

### DIFF
--- a/Api/AdministratorServices/FixHtIdService.cs
+++ b/Api/AdministratorServices/FixHtIdService.cs
@@ -1,11 +1,16 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
+using HappyTravel.Edo.Api.AdministratorServices.Mapper.AccommodationManagementServices;
+using HappyTravel.Edo.Api.Infrastructure;
+using HappyTravel.Edo.Api.Models.Bookings;
 using HappyTravel.Edo.Api.Services.Accommodations.Availability.Mapping;
 using HappyTravel.Edo.Data;
 using HappyTravel.Edo.Data.Bookings;
 using HappyTravel.MapperContracts.Public.Accommodations;
+using HappyTravel.MapperContracts.Public.Management.Accommodations.DetailedAccommodations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -14,14 +19,18 @@ namespace HappyTravel.Edo.Api.AdministratorServices
 {
     public class FixHtIdService : IFixHtIdService
     {
-        public FixHtIdService(EdoContext context, IAccommodationMapperClient client, ILogger<FixHtIdService> logger)
+        public FixHtIdService(IMapperManagementClient mapperManagementClient,
+            EdoContext context,
+            IAccommodationMapperClient client,
+            ILogger<FixHtIdService> logger)
         {
             _context = context;
             _client = client;
             _logger = logger;
+            _mapperManagementClient = mapperManagementClient;
         }
-        
-        
+
+
         public async Task FillEmptyHtIds()
         {
             var bookingsWithEmptyHtId = await _context.Bookings
@@ -37,37 +46,79 @@ namespace HappyTravel.Edo.Api.AdministratorServices
                     UpdateHtId(booking, result);
                     continue;
                 }
-                
+
                 var accommodationResult = await _client.GetAccommodation(booking.SupplierCode, booking.AccommodationId, booking.LanguageCode);
                 accommodationsCache.Add((booking.SupplierCode, booking.AccommodationId), accommodationResult);
                 UpdateHtId(booking, accommodationResult);
             }
-            
+
             await _context.SaveChangesAsync();
             _context.ChangeTracker.Clear();
-            
+
             var errors = accommodationsCache.Where(c => c.Value.IsFailure)
                 .ToDictionary(e => $"{e.Key.Item1}:{e.Key.Item2}", e => e.Value.Error.Detail);
-            
+
             if (errors.Any())
                 _logger.LogError("Updating errors {Errors}", errors);
-            
+
             _logger.LogInformation("Updating {Count} completed", bookingsWithEmptyHtId.Count);
+
+
+            void UpdateHtId(Booking booking, Result<Accommodation, ProblemDetails> accommodationResult)
+            {
+                if (accommodationResult.IsFailure)
+                    return;
+
+                booking.HtId = accommodationResult.Value.HtId;
+                _context.Bookings.Attach(booking).Property(b => b.HtId).IsModified = true;
+            }
         }
 
 
-        private void UpdateHtId(Booking booking, Result<Accommodation,ProblemDetails> accommodationResult)
+        public async Task<List<int>> FixAccommodationIds(BookingCreationPeriod request, CancellationToken cancellationToken)
         {
-            if (accommodationResult.IsFailure)
-                return;
+            var successedResultIds = new List<int>();
 
-            booking.HtId = accommodationResult.Value.HtId;
-            _context.Bookings.Attach(booking).Property(b => b.HtId).IsModified = true;
+            var bookings = await _context.Bookings
+                .Where(b => b.Created.DateTime >= request.StartWith && b.Created.DateTime <= request.EndWith)
+                .ToListAsync();
+
+            foreach (var booking in bookings)
+            {
+                var accommodationResult =
+                    await _mapperManagementClient.GetDetailedAccommodationData(booking.AccommodationId,
+                        LocalizationHelper.DefaultLanguageCode, cancellationToken);
+
+                UpdateAccommodationId(booking, accommodationResult);
+            }
+
+            await _context.SaveChangesAsync();
+            _context.ChangeTracker.Clear();
+
+            return successedResultIds;
+
+            void UpdateAccommodationId(Booking booking, Result<DetailedAccommodation, ProblemDetails> accommodationResult)
+            {
+                if (accommodationResult.IsFailure)
+                    return;
+
+                var isExist = accommodationResult.Value.SuppliersRawAccommodationData
+                    .TryGetValue(booking.SupplierCode, out var supplierAccommodation);
+
+                if (isExist)
+                {
+                    booking.AccommodationId = supplierAccommodation!.SupplierCode;
+                    _context.Bookings.Attach(booking).Property(b => b.AccommodationId).IsModified = true;
+
+                    successedResultIds.Add(booking.Id);
+                }
+            }
         }
 
 
         private readonly EdoContext _context;
         private readonly IAccommodationMapperClient _client;
+        private readonly IMapperManagementClient _mapperManagementClient;
         private readonly ILogger<FixHtIdService> _logger;
     }
 }

--- a/Api/AdministratorServices/IFixHtIdService.cs
+++ b/Api/AdministratorServices/IFixHtIdService.cs
@@ -1,9 +1,13 @@
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using HappyTravel.Edo.Api.Models.Bookings;
 
 namespace HappyTravel.Edo.Api.AdministratorServices
 {
     public interface IFixHtIdService
     {
         Task FillEmptyHtIds();
+        Task<List<int>> FixAccommodationIds(BookingCreationPeriod request, CancellationToken cancellationToken = default);
     }
 }

--- a/Api/Controllers/AdministratorControllers/BookingsController.cs
+++ b/Api/Controllers/AdministratorControllers/BookingsController.cs
@@ -36,7 +36,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
             IBookingInfoService bookingInfoService,
             IFixHtIdService fixHtIdService,
             IBookingRecordManager bookingRecordManager,
-            IDateTimeProvider dateTimeProvider, 
+            IDateTimeProvider dateTimeProvider,
             IAdministratorBookingDocumentsService bookingDocumentsService)
         {
             _administratorContext = administratorContext;
@@ -63,7 +63,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         {
             var (count, bookings) = await _bookingService.GetAllBookings(opts);
             HttpContext.Response.Headers.Add(CountHeader, count.ToString());
-            
+
             return bookings;
         }
 
@@ -82,7 +82,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         {
             var (count, bookings) = await _bookingService.GetAgencyBookings(agencyId, opts);
             HttpContext.Response.Headers.Add(CountHeader, count.ToString());
-            
+
             return bookings;
         }
 
@@ -101,7 +101,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         {
             var (count, bookings) = await _bookingService.GetAgentBookings(agentId, opts);
             HttpContext.Response.Headers.Add(CountHeader, count.ToString());
-            
+
             return bookings;
         }
 
@@ -262,8 +262,8 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
 
             return NoContent();
         }
-        
-        
+
+
         /// <summary>
         ///     Gets booking voucher PDF document.
         /// </summary>
@@ -271,14 +271,14 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         /// <returns>Voucher PDF document.</returns>
         [HttpGet("accommodations/bookings/{bookingId}/voucher-pdf")]
         [ProducesResponseType((int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(ProblemDetails), (int) HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
         [AdministratorPermissions(AdministratorPermissions.BookingManagement)]
         public async Task<IActionResult> GetBookingVoucherPdf(int bookingId)
         {
             var (_, isFailure, document, error) = await _bookingDocumentsService.GenerateVoucherPdf(bookingId, LanguageCode);
             if (isFailure)
                 return BadRequest(ProblemDetailsBuilder.Build(error));
-            
+
             return File(document, "application/pdf");
         }
 
@@ -330,6 +330,18 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
         [AdministratorPermissions(AdministratorPermissions.ViewBookings)]
         public async Task<ActionResult<List<AdministratorBookingStatusHistoryEntry>>> GetBookingStatusHistory(int bookingId)
             => await _bookingInfoService.GetAdministratorBookingStatusHistory(bookingId);
+
+
+        /// <summary>
+        ///     Fills empty htId in bookings
+        /// </summary>
+        /// <returns></returns>
+        [HttpPost("accommodations/bookings/fix-accommodation-ids")]
+        [ProducesResponseType(typeof(List<int>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
+        [AdministratorPermissions(AdministratorPermissions.BookingManagement)]
+        public async Task<IActionResult> FixAccommodationIds([FromBody] BookingCreationPeriod request)
+            => Ok(await _fixHtIdService.FixAccommodationIds(request));
 
 
         private readonly IAdministratorBookingDocumentsService _bookingDocumentsService;

--- a/Api/Controllers/AdministratorControllers/BookingsController.cs
+++ b/Api/Controllers/AdministratorControllers/BookingsController.cs
@@ -333,7 +333,7 @@ namespace HappyTravel.Edo.Api.Controllers.AdministratorControllers
 
 
         /// <summary>
-        ///     Fills empty htId in bookings
+        ///     Fix accommodation ids in bookings in specific creation period
         /// </summary>
         /// <returns></returns>
         [HttpPost("accommodations/bookings/fix-accommodation-ids")]

--- a/Api/HappyTravel.Edo.Api.xml
+++ b/Api/HappyTravel.Edo.Api.xml
@@ -529,6 +529,12 @@
             <param name="bookingId">Booking ID for retrieving status change history</param>
             <returns>List of booking status change events</returns>
         </member>
+        <member name="M:HappyTravel.Edo.Api.Controllers.AdministratorControllers.BookingsController.FixAccommodationIds(HappyTravel.Edo.Api.Models.Bookings.BookingCreationPeriod)">
+            <summary>
+                Fills empty htId in bookings
+            </summary>
+            <returns></returns>
+        </member>
         <member name="M:HappyTravel.Edo.Api.Controllers.AdministratorControllers.CompanyAccountsController.GetCompanyInfo">
             <summary>
             Gets the company information.

--- a/Api/Models/Bookings/BookingCreationPeriod.cs
+++ b/Api/Models/Bookings/BookingCreationPeriod.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace HappyTravel.Edo.Api.Models.Bookings;
+
+public readonly struct BookingCreationPeriod
+{
+    [JsonConstructor]
+    public BookingCreationPeriod(DateTime startWith, DateTime endWith)
+    {
+        StartWith = startWith;
+        EndWith = endWith;
+    }
+
+
+    public DateTime StartWith { get; }
+    public DateTime EndWith { get; }
+
+}


### PR DESCRIPTION
Issue: https://github.com/happy-travel/edo/issues/2084
Insomnia: Edo -> Admin -> Bookings -> Fix accommodation id in booking
Tested through insomnia

Endpoint find bookings within specific creation time period. Then requests to mapper by accommodationId if it htId it works well and swap bookings accommodationId by SupplierCode.