### PR TITLE
Regenerate invoice when payment method changes

### DIFF
--- a/Api/Services/Documents/IInvoiceService.cs
+++ b/Api/Services/Documents/IInvoiceService.cs
@@ -9,13 +9,7 @@ namespace HappyTravel.Edo.Api.Services.Documents
     {
         Task<DocumentRegistrationInfo> Register<TInvoiceData>(ServiceTypes serviceType, ServiceSource serviceSource, string referenceCode, TInvoiceData data);
 
-        Task Update(List<Invoice> invoices);
-
-
         Task<List<(DocumentRegistrationInfo Metadata, TInvoiceData Data)>> Get<TInvoiceData>(ServiceTypes serviceType, ServiceSource serviceSource,
-            string referenceCode);
-
-        Task<List<Invoice>> GetInvoices(ServiceTypes serviceType, ServiceSource serviceSource,
             string referenceCode);
     }
 }

--- a/Api/Services/Documents/InvoiceService.cs
+++ b/Api/Services/Documents/InvoiceService.cs
@@ -26,14 +26,10 @@ namespace HappyTravel.Edo.Api.Services.Documents
                 ParentReferenceCode = referenceCode,
                 Data = _serializer.SerializeObject(data)
             };
-            
+
             return _documentsStorage
                 .Register(invoice, (id, regDate) => $"INV-{id:000}/{regDate.Year}");
         }
-
-
-        public Task Update(List<Invoice> invoices)
-            => _documentsStorage.Update(invoices);
 
 
         public async Task<List<(DocumentRegistrationInfo Metadata, TInvoiceData Data)>> Get<TInvoiceData>(ServiceTypes serviceType, ServiceSource serviceSource,
@@ -44,11 +40,6 @@ namespace HappyTravel.Edo.Api.Services.Documents
                 .Select(r => (r.GetRegistrationInfo(), _serializer.DeserializeObject<TInvoiceData>(r.Data)))
                 .ToList();
         }
-
-
-        public Task<List<Invoice>> GetInvoices(ServiceTypes serviceType, ServiceSource serviceSource,
-            string referenceCode)
-            => _documentsStorage.Get<Invoice>(serviceType, serviceSource, referenceCode);
 
 
         private readonly IPaymentDocumentsStorage _documentsStorage;


### PR DESCRIPTION
Issue: https://github.com/happy-travel/agent-app-project/issues/1741

Invoice regenerates each times when existing booking's payment type or price changing.
Check if invoice regenerates when booking with payment type VirtualAccount pays with creditCard